### PR TITLE
Add AI Ethics & Compliance page with navigation links

### DIFF
--- a/ai-ethics/index.html
+++ b/ai-ethics/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Ethics & Compliance - Randstad GBS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../shared/hub-button.css">
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+     .google-sans { font-family: 'Google Sans', sans-serif; }
+     body { font-family: 'Roboto', sans-serif; }
+  </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+
+  <div class="container mx-auto px-4 py-12 md:py-20">
+    <header class="text-center mb-12">
+      <h1 class="google-sans text-4xl md:text-5xl font-bold text-gray-900">AI Ethics & Compliance</h1>
+      <p class="mt-4 text-lg text-gray-600 max-w-2xl mx-auto">Guidelines on data privacy, fairness, and Randstad's responsible AI policies.</p>
+    </header>
+
+    <main class="space-y-12 max-w-3xl mx-auto">
+
+      <section>
+        <h2 class="google-sans text-2xl font-bold text-gray-900 mb-4">Data Privacy</h2>
+        <p class="text-gray-700 mb-4">Protecting personal information is at the core of Randstad's use of AI. Our systems follow strict data-minimization and security practices.</p>
+        <ul class="list-disc list-inside text-gray-700">
+          <li><a href="https://www.randstad.com/privacy-statement" class="text-blue-600 hover:underline">Randstad Global Data Privacy Policy</a></li>
+          <li><a href="https://gdpr.eu/" class="text-blue-600 hover:underline" target="_blank" rel="noopener">General Data Protection Regulation (GDPR)</a></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="google-sans text-2xl font-bold text-gray-900 mb-4">Fairness & Bias</h2>
+        <p class="text-gray-700 mb-4">We design and evaluate AI solutions to ensure equitable outcomes and to minimize unintended bias.</p>
+        <ul class="list-disc list-inside text-gray-700">
+          <li><a href="https://www.randstad.com/sustainability/tech-and-touch/ai-principles" class="text-blue-600 hover:underline">Randstad AI Ethics Policy</a></li>
+          <li><a href="https://artificialintelligenceact.eu/" class="text-blue-600 hover:underline" target="_blank" rel="noopener">EU AI Act</a></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="google-sans text-2xl font-bold text-gray-900 mb-4">Randstad’s AI Policies</h2>
+        <p class="text-gray-700 mb-4">Our policies govern responsible development and deployment of AI across Randstad’s services.</p>
+        <ul class="list-disc list-inside text-gray-700">
+          <li><a href="https://www.randstad.com/esg/ethical-conduct" class="text-blue-600 hover:underline">Code of Conduct</a></li>
+          <li><a href="https://www.randstad.com/sustainability/tech-and-touch" class="text-blue-600 hover:underline">Tech & Touch Strategy</a></li>
+        </ul>
+      </section>
+
+    </main>
+  </div>
+
+  <div id="footer-placeholder"></div>
+  <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
                     <h3 class="google-sans text-2xl font-bold mb-2">AI SME</h3>
                     <p class="text-gray-600">Explore expert AI knowledge and resources.</p>
                 </a>
+                <a href="/ai-ethics/" class="hub-card bg-white p-8 rounded-xl block">
+                    <h3 class="google-sans text-2xl font-bold mb-2">AI Ethics & Compliance</h3>
+                    <p class="text-gray-600">Guidance on data privacy, fairness, and Randstad's AI policies.</p>
+                </a>
 
                 <a href="/use-cases/" class="hub-card bg-white p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">AI Success Stories</h3>

--- a/shared/footer.html
+++ b/shared/footer.html
@@ -18,6 +18,8 @@
                             <a href="/about-us/"
                                 class="block text-sm text-gray-600 hover:text-blue-600 transition-colors duration-200">About
                                 Us</a>
+                            <a href="/ai-ethics/"
+                                class="block text-sm text-gray-600 hover:text-blue-600 transition-colors duration-200">AI Ethics & Compliance</a>
                             <a href="/gbs-prompts/"
                                 class="block text-sm text-gray-600 hover:text-blue-600 transition-colors duration-200">Prompt
                                 Library</a>


### PR DESCRIPTION
## Summary
- Add new AI Ethics & Compliance page covering data privacy, fairness, and Randstad AI policy resources
- Link AI Ethics & Compliance from home page and shared footer navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b945f5e0848330abd57b4cc2602ceb