### PR TITLE
Add AI glossary and link across learning hub

### DIFF
--- a/ai-glossary/index.html
+++ b/ai-glossary/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Glossary</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        .google-sans {
+            font-family: 'Google Sans', sans-serif;
+        }
+        body {
+            font-family: 'Roboto', sans-serif;
+        }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <div class="container mx-auto px-4 py-12">
+        <header class="mb-8 text-center">
+            <h1 class="google-sans text-4xl font-bold mb-4">AI Glossary</h1>
+            <p class="text-gray-600">Alphabetical reference for common AI terms.</p>
+        </header>
+
+        <nav class="flex flex-wrap gap-2 justify-center mb-8">
+            <a href="#A" class="text-blue-600 hover:underline">A</a>
+            <a href="#B" class="text-blue-600 hover:underline">B</a>
+            <a href="#D" class="text-blue-600 hover:underline">D</a>
+            <a href="#M" class="text-blue-600 hover:underline">M</a>
+            <a href="#N" class="text-blue-600 hover:underline">N</a>
+            <a href="#P" class="text-blue-600 hover:underline">P</a>
+        </nav>
+
+        <main class="space-y-8">
+            <section id="A">
+                <h2 class="google-sans text-2xl font-semibold mb-4">A</h2>
+                <dl>
+                    <div class="mb-4">
+                        <dt class="font-bold">Algorithm</dt>
+                        <dd class="text-gray-700">A set of rules or instructions a computer follows to solve a problem or complete a task.</dd>
+                    </div>
+                    <div class="mb-4">
+                        <dt class="font-bold">Artificial Intelligence (AI)</dt>
+                        <dd class="text-gray-700">The field of creating systems that can perform tasks typically requiring human intelligence.</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section id="B">
+                <h2 class="google-sans text-2xl font-semibold mb-4">B</h2>
+                <dl>
+                    <div class="mb-4">
+                        <dt class="font-bold">Bias</dt>
+                        <dd class="text-gray-700">Systematic errors that lead to unfair outcomes, often reflecting prejudices in training data.</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section id="D">
+                <h2 class="google-sans text-2xl font-semibold mb-4">D</h2>
+                <dl>
+                    <div class="mb-4">
+                        <dt class="font-bold">Dataset</dt>
+                        <dd class="text-gray-700">A collection of data used to train or evaluate AI models.</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section id="M">
+                <h2 class="google-sans text-2xl font-semibold mb-4">M</h2>
+                <dl>
+                    <div class="mb-4">
+                        <dt class="font-bold">Machine Learning (ML)</dt>
+                        <dd class="text-gray-700">A subset of AI that enables systems to learn from data and improve over time without being explicitly programmed.</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section id="N">
+                <h2 class="google-sans text-2xl font-semibold mb-4">N</h2>
+                <dl>
+                    <div class="mb-4">
+                        <dt class="font-bold">Neural Network</dt>
+                        <dd class="text-gray-700">A network of algorithms modeled after the human brain, used to recognize patterns and solve complex problems.</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section id="P">
+                <h2 class="google-sans text-2xl font-semibold mb-4">P</h2>
+                <dl>
+                    <div class="mb-4">
+                        <dt class="font-bold">Prompt</dt>
+                        <dd class="text-gray-700">A textual or structured input that guides an AI model to generate a specific output.</dd>
+                    </div>
+                </dl>
+            </section>
+        </main>
+    </div>
+
+    <div id="footer-placeholder"></div>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -83,6 +83,11 @@
                     <p class="text-gray-600">An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement. (Coming Soon)</p>
                 </a>
 
+                <a href="/ai-glossary/" class="hub-card bg-white p-8 rounded-xl block">
+                    <h3 class="google-sans text-2xl font-bold mb-2">AI Glossary</h3>
+                    <p class="text-gray-600">Quick reference of common AI terms and definitions.</p>
+                </a>
+
             </div>
         </main>
     </div>

--- a/shared/footer.html
+++ b/shared/footer.html
@@ -31,6 +31,8 @@
                                 Focus</a>
                             <a href="/feedback/"
                                 class="block text-sm text-gray-600 hover:text-blue-600 transition-colors duration-200">Feedback</a>
+                            <a href="/ai-glossary/"
+                                class="block text-sm text-gray-600 hover:text-blue-600 transition-colors duration-200">AI Glossary</a>
                         </nav>
                     </div>
 


### PR DESCRIPTION
## Summary
- Add AI Glossary page with anchor navigation for quick lookup of key terms
- Link new glossary from main landing page and global footer

## Testing
- `npm test` *(fails: ENOENT: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94909408483308db54dbd7cc8cb86