### PR TITLE
Add role-specific training tracks for RPO program

### DIFF
--- a/rpo-training/index.html
+++ b/rpo-training/index.html
@@ -37,6 +37,27 @@
                     module below to begin.</p>
             </div>
 
+            <div class="content-section">
+                <h3 class="google-sans text-3xl font-bold text-center">Role-Specific Tracks</h3>
+                <div class="mt-8 grid md:grid-cols-3 gap-6">
+                    <a href="recruiter/index.html" class="module-card text-center">
+                        <p class="text-sm font-semibold text-blue-600">RECRUITER</p>
+                        <h4 class="google-sans text-xl font-bold mt-2">Recruiter Track</h4>
+                        <p class="mt-2 text-gray-600">Candidate outreach and interview tools.</p>
+                    </a>
+                    <a href="sourcer/index.html" class="module-card text-center">
+                        <p class="text-sm font-semibold text-blue-600">SOURCER</p>
+                        <h4 class="google-sans text-xl font-bold mt-2">Sourcer Track</h4>
+                        <p class="mt-2 text-gray-600">Talent discovery and pipeline skills.</p>
+                    </a>
+                    <a href="manager/index.html" class="module-card text-center">
+                        <p class="text-sm font-semibold text-blue-600">MANAGER</p>
+                        <h4 class="google-sans text-xl font-bold mt-2">Manager Track</h4>
+                        <p class="mt-2 text-gray-600">Team leadership and AI governance.</p>
+                    </a>
+                </div>
+            </div>
+
             <!-- Phase 1 Section -->
             <section class="phase-section">
                 <div class="grid md:grid-cols-2 gap-8 items-center">

--- a/rpo-training/manager/index.html
+++ b/rpo-training/manager/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RPO Training - Manager Track</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../shared/hub-button.css">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body class="text-gray-800">
+  <header class="bg-white site-header sticky top-0 z-10">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+      <h1 class="google-sans text-2xl text-gray-700">Manager Track</h1>
+      <a href="../index.html" class="hub-button">Back To Training Hub</a>
+    </div>
+  </header>
+  <main class="max-w-5xl mx-auto px-6">
+    <section class="content-section text-center">
+      <h2 class="google-sans text-3xl font-bold text-gray-800">Modules</h2>
+    </section>
+    <section class="content-section">
+      <h3 class="google-sans text-2xl font-bold text-blue-600">Module 1: Team Productivity Dashboard</h3>
+      <div class="mt-4">
+        <iframe class="w-full aspect-video rounded" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Team Productivity" allowfullscreen></iframe>
+      </div>
+      <p class="mt-4 text-gray-600">Prompt to monitor performance:</p>
+      <div class="prompt-box text-sm mt-2">Design a dashboard using AI tools that tracks recruiter activity and highlights bottlenecks.</div>
+    </section>
+    <section class="content-section">
+      <h3 class="google-sans text-2xl font-bold text-blue-600">Module 2: Ethical AI Policies</h3>
+      <div class="mt-4">
+        <iframe class="w-full aspect-video rounded" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Ethical AI" allowfullscreen></iframe>
+      </div>
+      <p class="mt-4 text-gray-600">Prompt to draft guidelines:</p>
+      <div class="prompt-box text-sm mt-2">Outline an AI usage policy for a recruiting team that balances innovation with candidate privacy.</div>
+    </section>
+  </main>
+  <div id="footer-placeholder"></div>
+  <script src="../../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/rpo-training/recruiter/index.html
+++ b/rpo-training/recruiter/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RPO Training - Recruiter Track</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../shared/hub-button.css">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body class="text-gray-800">
+  <header class="bg-white site-header sticky top-0 z-10">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+      <h1 class="google-sans text-2xl text-gray-700">Recruiter Track</h1>
+      <a href="../index.html" class="hub-button">Back To Training Hub</a>
+    </div>
+  </header>
+  <main class="max-w-5xl mx-auto px-6">
+    <section class="content-section text-center">
+      <h2 class="google-sans text-3xl font-bold text-gray-800">Modules</h2>
+    </section>
+    <section class="content-section">
+      <h3 class="google-sans text-2xl font-bold text-blue-600">Module 1: Candidate Outreach with AI</h3>
+      <div class="mt-4">
+        <iframe class="w-full aspect-video rounded" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Candidate Outreach" allowfullscreen></iframe>
+      </div>
+      <p class="mt-4 text-gray-600">Prompt to personalize outreach messages:</p>
+      <div class="prompt-box text-sm mt-2">You are a recruiter. Draft a friendly outreach email to a software engineer highlighting why our company is a great next step.</div>
+    </section>
+    <section class="content-section">
+      <h3 class="google-sans text-2xl font-bold text-blue-600">Module 2: Interview Scheduling Automation</h3>
+      <div class="mt-4">
+        <iframe class="w-full aspect-video rounded" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Interview Scheduling" allowfullscreen></iframe>
+      </div>
+      <p class="mt-4 text-gray-600">Prompt to streamline scheduling:</p>
+      <div class="prompt-box text-sm mt-2">Generate a step-by-step plan using AI tools to automate interview scheduling for multiple candidates.</div>
+    </section>
+  </main>
+  <div id="footer-placeholder"></div>
+  <script src="../../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/rpo-training/sourcer/index.html
+++ b/rpo-training/sourcer/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RPO Training - Sourcer Track</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../shared/hub-button.css">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body class="text-gray-800">
+  <header class="bg-white site-header sticky top-0 z-10">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+      <h1 class="google-sans text-2xl text-gray-700">Sourcer Track</h1>
+      <a href="../index.html" class="hub-button">Back To Training Hub</a>
+    </div>
+  </header>
+  <main class="max-w-5xl mx-auto px-6">
+    <section class="content-section text-center">
+      <h2 class="google-sans text-3xl font-bold text-gray-800">Modules</h2>
+    </section>
+    <section class="content-section">
+      <h3 class="google-sans text-2xl font-bold text-blue-600">Module 1: Boolean Search Mastery</h3>
+      <div class="mt-4">
+        <iframe class="w-full aspect-video rounded" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Boolean Search" allowfullscreen></iframe>
+      </div>
+      <p class="mt-4 text-gray-600">Prompt to craft complex search strings:</p>
+      <div class="prompt-box text-sm mt-2">Create a Boolean string to find data scientists with Python and NLP experience across Europe.</div>
+    </section>
+    <section class="content-section">
+      <h3 class="google-sans text-2xl font-bold text-blue-600">Module 2: Building Talent Pipelines</h3>
+      <div class="mt-4">
+        <iframe class="w-full aspect-video rounded" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Pipeline Building" allowfullscreen></iframe>
+      </div>
+      <p class="mt-4 text-gray-600">Prompt to generate outreach sequences:</p>
+      <div class="prompt-box text-sm mt-2">Outline a three-touch outreach cadence for passive candidates interested in remote work.</div>
+    </section>
+  </main>
+  <div id="footer-placeholder"></div>
+  <script src="../../shared/scripts/footer.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add recruiter, sourcer and manager training track pages with videos and prompt examples
- link new role-specific tracks from the RPO training overview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94de6dab48330b6f94a177bf93d06