### PR TITLE
Add events page and link from hub and modules

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Events & Sessions</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <header class="bg-white shadow">
+        <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+            <h1 class="text-2xl font-bold">Events & Sessions</h1>
+            <a href="../index.html" class="hub-button">Back To Hub</a>
+        </div>
+    </header>
+    <main class="max-w-5xl mx-auto px-6 py-8">
+        <p class="mb-6 text-gray-600">Join our upcoming training and workshop sessions.</p>
+        <div class="space-y-6">
+            <div class="bg-white p-6 rounded-lg shadow">
+                <h2 class="text-xl font-semibold">GBS AI Workshop - April 30</h2>
+                <p class="mt-2 text-gray-600">Interactive session for leaders.</p>
+                <a href="https://example.com/register/workshop" target="_blank" class="text-blue-600 underline">Register</a>
+            </div>
+            <div class="bg-white p-6 rounded-lg shadow">
+                <h2 class="text-xl font-semibold">RPO Training Session - May 5</h2>
+                <p class="mt-2 text-gray-600">Foundations of AI for recruitment.</p>
+                <a href="https://example.com/register/rpo" target="_blank" class="text-blue-600 underline">Register</a>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/gbs-ai-workshop/index.html
+++ b/gbs-ai-workshop/index.html
@@ -83,7 +83,10 @@
                     <span class="text-xl font-bold text-[#4A90E2]">Randstad GBS</span>
                     <span class="ml-2 text-xl font-light text-gray-600">| Gemini for Leaders</span>
                 </div>
-                <a href="../index.html" class="hub-button">Back To Hub</a>
+                <div class="flex items-center space-x-4">
+                    <a href="../events/" class="hub-button">Events</a>
+                    <a href="../index.html" class="hub-button">Back To Hub</a>
+                </div>
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-center space-x-4">
                         <a href="#why" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">The Why</a>

--- a/index.html
+++ b/index.html
@@ -93,6 +93,11 @@
                     <p class="text-gray-600">Answers to common AI questions, access issues, and escalation paths.</p>
                 </a>
 
+                <a href="/events/" class="hub-card bg-white p-8 rounded-xl block">
+                    <h3 class="google-sans text-2xl font-bold mb-2">Events &amp; Sessions</h3>
+                    <p class="text-gray-600">View upcoming training dates and register to participate.</p>
+                </a>
+
                 </div>
         </main>
     </div>

--- a/rpo-training/index.html
+++ b/rpo-training/index.html
@@ -21,7 +21,10 @@
     <header class="bg-white site-header sticky top-0 z-10">
         <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
             <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
-            <a href="../index.html" class="hub-button">Back To Hub</a>
+            <div class="space-x-4">
+                <a href="../events/" class="hub-button">Events</a>
+                <a href="../index.html" class="hub-button">Back To Hub</a>
+            </div>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- add `/events` page with upcoming session list and registration links
- link events page from main hub, RPO training, and GBS workshop modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9596b3f1c83308f4f56837fca63cb