### PR TITLE
Add reusable resources library and links

### DIFF
--- a/ai-ethics/index.html
+++ b/ai-ethics/index.html
@@ -49,6 +49,11 @@
         </ul>
       </section>
 
+      <section>
+        <h2 class="google-sans text-2xl font-bold text-gray-900 mb-4">Templates &amp; Checklists</h2>
+        <p class="text-gray-700">Download policy checklist templates in the <a href="../resources/" class="text-blue-600 hover:underline">Resource Templates library</a>.</p>
+      </section>
+
     </main>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -88,15 +88,20 @@
                     <p class="text-gray-600">Quick reference of common AI terms and definitions.</p>
                 </a>
 
-                <a href="/faq/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">FAQ</h3>
-                    <p class="text-gray-600">Answers to common AI questions, access issues, and escalation paths.</p>
-                </a>
+                  <a href="/faq/" class="hub-card bg-white p-8 rounded-xl block">
+                      <h3 class="google-sans text-2xl font-bold mb-2">FAQ</h3>
+                      <p class="text-gray-600">Answers to common AI questions, access issues, and escalation paths.</p>
+                  </a>
 
-                <a href="/events/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">Events &amp; Sessions</h3>
-                    <p class="text-gray-600">View upcoming training dates and register to participate.</p>
-                </a>
+                  <a href="/resources/" class="hub-card bg-white p-8 rounded-xl block">
+                      <h3 class="google-sans text-2xl font-bold mb-2">Resource Templates</h3>
+                      <p class="text-gray-600">Download reusable documents like sourcing scripts and policy checklists.</p>
+                  </a>
+
+                  <a href="/events/" class="hub-card bg-white p-8 rounded-xl block">
+                      <h3 class="google-sans text-2xl font-bold mb-2">Events &amp; Sessions</h3>
+                      <p class="text-gray-600">View upcoming training dates and register to participate.</p>
+                  </a>
 
                 </div>
         </main>

--- a/resources/index.html
+++ b/resources/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reusable Templates Library</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        .google-sans { font-family: 'Google Sans', sans-serif; }
+        body { font-family: 'Roboto', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+
+    <div class="container mx-auto px-4 py-12 md:py-20">
+        <header class="text-center mb-12">
+            <h1 class="google-sans text-4xl md:text-5xl font-bold text-gray-900">Reusable Templates Library</h1>
+            <p class="mt-4 text-lg text-gray-600 max-w-2xl mx-auto">Download ready-to-use documents for sourcing and compliance.</p>
+        </header>
+
+        <main class="space-y-12 max-w-3xl mx-auto">
+            <section>
+                <h2 class="google-sans text-2xl font-bold text-gray-900 mb-4">Sourcing Scripts</h2>
+                <ul class="list-disc list-inside text-gray-700">
+                    <li><a href="sourcing-script-template.pdf" class="text-blue-600 hover:underline" target="_blank">Sourcing Script Template (PDF)</a></li>
+                </ul>
+            </section>
+
+            <section>
+                <h2 class="google-sans text-2xl font-bold text-gray-900 mb-4">Policy Checklists</h2>
+                <ul class="list-disc list-inside text-gray-700">
+                    <li><a href="policy-checklist-template.pdf" class="text-blue-600 hover:underline" target="_blank">Policy Checklist Template (PDF)</a></li>
+                </ul>
+            </section>
+        </main>
+    </div>
+
+    <a href="../index.html" class="hub-button">Back To Hub</a>
+    <div id="footer-placeholder"></div>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/resources/policy-checklist-template.pdf
+++ b/resources/policy-checklist-template.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 57 >>
+stream
+BT /F1 24 Tf 100 700 Td (Policy Checklist Template) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000348 00000 n 
+trailer << /Root 1 0 R /Size 6 >>
+startxref
+418
+%%EOF

--- a/resources/sourcing-script-template.pdf
+++ b/resources/sourcing-script-template.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 56 >>
+stream
+BT /F1 24 Tf 100 700 Td (Sourcing Script Template) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000347 00000 n 
+trailer << /Root 1 0 R /Size 6 >>
+startxref
+417
+%%EOF

--- a/rpo-training/index.html
+++ b/rpo-training/index.html
@@ -23,6 +23,7 @@
             <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
             <div class="space-x-4">
                 <a href="../events/" class="hub-button">Events</a>
+                <a href="../resources/" class="hub-button">Resources</a>
                 <a href="../index.html" class="hub-button">Back To Hub</a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add Resource Templates library with sourcing scripts and policy checklist PDFs
- link resources library from landing page, RPO training header, and AI ethics page

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b95aacab7c8330b63a956aa36377e3