### PR TITLE
Add sourcing workshop page and update landing card

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 
                 <a href="/sourcing-workshop/" class="hub-card bg-white p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">Sourcing Workshop</h3>
-                    <p class="text-gray-600">An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement. (Coming Soon)</p>
+                    <p class="text-gray-600">An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement.</p>
                 </a>
 
                 <a href="/ai-glossary/" class="hub-card bg-white p-8 rounded-xl block">

--- a/sourcing-workshop/index.html
+++ b/sourcing-workshop/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sourcing Workshop</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        .google-sans {
+            font-family: 'Google Sans', sans-serif;
+        }
+        body {
+            font-family: 'Roboto', sans-serif;
+        }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <div class="container mx-auto px-4 py-8">
+        <header class="mb-8 text-center">
+            <h1 class="google-sans text-4xl font-bold mb-4">Sourcing Workshop</h1>
+            <nav class="space-x-4">
+                <a href="#market-intelligence" class="text-blue-600 hover:underline">Market Intelligence</a>
+                <a href="#engagement-tactics" class="text-blue-600 hover:underline">Engagement Tactics</a>
+            </nav>
+        </header>
+
+        <section id="market-intelligence" class="mb-12">
+            <h2 class="google-sans text-2xl font-bold mb-2">Market Intelligence</h2>
+            <p class="mb-4">Explore how to gather and interpret labor market data to target sourcing efforts effectively.</p>
+            <h3 class="font-semibold mb-2">Lesson Structure</h3>
+            <ul class="list-disc list-inside mb-4">
+                <li>Identify relevant data sources</li>
+                <li>Analyze supply and demand trends</li>
+                <li>Develop target candidate profiles</li>
+            </ul>
+            <h3 class="font-semibold mb-2">Exercises</h3>
+            <ul class="list-disc list-inside mb-4">
+                <li>Use a market report to map three emerging talent hubs.</li>
+                <li>Create a brief comparing competitor hiring trends.</li>
+            </ul>
+            <h3 class="font-semibold mb-2">Resources</h3>
+            <ul class="list-disc list-inside">
+                <li><a href="https://www.gartner.com/en/human-resources/insights/talent-intelligence" class="text-blue-600 hover:underline">Gartner: Talent Intelligence</a></li>
+                <li><a href="https://www.linkedin.com/talent/blog" class="text-blue-600 hover:underline">LinkedIn Talent Blog</a></li>
+            </ul>
+        </section>
+
+        <section id="engagement-tactics" class="mb-12">
+            <h2 class="google-sans text-2xl font-bold mb-2">Engagement Tactics</h2>
+            <p class="mb-4">Learn approaches for connecting with candidates and building lasting relationships.</p>
+            <h3 class="font-semibold mb-2">Lesson Structure</h3>
+            <ul class="list-disc list-inside mb-4">
+                <li>Craft personalized outreach messages</li>
+                <li>A/B test subject lines and calls to action</li>
+                <li>Design follow-up cadences</li>
+            </ul>
+            <h3 class="font-semibold mb-2">Exercises</h3>
+            <ul class="list-disc list-inside mb-4">
+                <li>Draft a cold outreach message for a niche role.</li>
+                <li>Experiment with two follow-up templates and compare response rates.</li>
+            </ul>
+            <h3 class="font-semibold mb-2">Resources</h3>
+            <ul class="list-disc list-inside">
+                <li><a href="https://www.hirerabbit.com/blog/sourcing-candidates/" class="text-blue-600 hover:underline">HireRabbit Sourcing Tips</a></li>
+                <li><a href="https://www.recruitingdaily.com/category/sourcing/" class="text-blue-600 hover:underline">RecruitingDaily: Sourcing Articles</a></li>
+            </ul>
+        </section>
+    </div>
+
+    <div id="footer-placeholder"></div>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Sourcing Workshop page with market intelligence and engagement tactics sections
- remove "(Coming Soon)" notice from Sourcing Workshop card on landing page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9649e76808330becfde9026e27680