### PR TITLE
Add configurable site-wide announcement banner

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -6,6 +6,7 @@
     <title>About Us | Gemini Prompts Library</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
         body {
@@ -106,6 +107,7 @@
     </main>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/ai-ethics/index.html
+++ b/ai-ethics/index.html
@@ -6,6 +6,7 @@
   <title>AI Ethics & Compliance - Randstad GBS</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
   <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
   <style>
      .google-sans { font-family: 'Google Sans', sans-serif; }
@@ -69,6 +70,7 @@
   </div>
 
   <div id="footer-placeholder"></div>
-  <script src="../shared/scripts/footer.js" defer></script>
+      <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/ai-glossary/index.html
+++ b/ai-glossary/index.html
@@ -6,6 +6,7 @@
     <title>AI Glossary</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         .google-sans {
@@ -100,6 +101,7 @@
     </div>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/ai-sme/index.html
+++ b/ai-sme/index.html
@@ -95,6 +95,7 @@
             font-size: 1.125rem;
         }
     </style>
+    <link rel="stylesheet" href="../shared/announcement.css">
 </head>
 <body class="bg-brand-bg text-brand-body font-sans leading-relaxed">
 
@@ -322,6 +323,7 @@
     </main>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 
     <script>

--- a/daily-focus/index.html
+++ b/daily-focus/index.html
@@ -6,6 +6,7 @@
     <title>Daily Sourcing Focus</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
         body {
@@ -113,6 +114,7 @@
     </div>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 
     <script>

--- a/events/index.html
+++ b/events/index.html
@@ -6,6 +6,7 @@
     <title>Events & Sessions</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
 </head>
 <body class="bg-gray-50 text-gray-800">
     <header class="bg-white shadow">
@@ -29,5 +30,6 @@
             </div>
         </div>
     </main>
+    <script src="../shared/announcement.js" defer></script>
 </body>
 </html>

--- a/faq/index.html
+++ b/faq/index.html
@@ -6,6 +6,7 @@
     <title>FAQ | Randstad GBS AI Hub</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <style>
         body {
             font-family: 'Roboto', sans-serif;
@@ -59,6 +60,7 @@
     </main>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/feedback/get-entry-ids.html
+++ b/feedback/get-entry-ids.html
@@ -13,6 +13,7 @@
         .results { background: white; padding: 15px; border-radius: 4px; margin: 10px 0; }
         .code { background: #f8f9fa; padding: 10px; border-radius: 4px; font-family: monospace; margin: 5px 0; }
     </style>
+    <link rel="stylesheet" href="../shared/announcement.css">
 </head>
 <body>
     <h1>Google Form Entry ID Extractor</h1>
@@ -79,6 +80,7 @@
     </script>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/feedback/index.html
+++ b/feedback/index.html
@@ -7,6 +7,7 @@
     <title>Feedback - Randstad GBS Learning Hub</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link
         href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap"
         rel="stylesheet">
@@ -220,6 +221,7 @@
     </div>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 
     <script>

--- a/gbs-ai-workshop/index.html
+++ b/gbs-ai-workshop/index.html
@@ -12,6 +12,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <style>
          .code-block {
              background-color: #f3f4f6;
@@ -2203,5 +2204,6 @@
         });
 
     </script>
+    <script src="../shared/announcement.js" defer></script>
 </body>
 </html>

--- a/gbs-prompts/index.html
+++ b/gbs-prompts/index.html
@@ -7,6 +7,7 @@
     <title>Gemini Prompt Library</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
@@ -1288,6 +1289,7 @@ copyGemBtn.addEventListener('click', () => {
     </div>
 </div>
     </div>
+    <script src="../shared/announcement.js" defer></script>
 </body>
 
 </html>

--- a/gbs-prompts/waywethink.html
+++ b/gbs-prompts/waywethink.html
@@ -6,6 +6,7 @@
   <title>A New Way of Thinking | GBS AI Initiative</title>
   <script src="https://cdn.tailwindcss.com"></script>
 	<link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
   <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
   body {
@@ -131,6 +132,7 @@
 	</main>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
  </body>
  </html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Randstad GBS - AI Hub</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="shared/hub-button.css">
+    <link rel="stylesheet" href="shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         .google-sans {
@@ -108,6 +109,7 @@
     </div>
 
     <div id="footer-placeholder"></div>
+        <script src="shared/announcement.js" defer></script>
     <script src="shared/scripts/footer.js" defer></script>
 </body>
 

--- a/knowledge-content/index.html
+++ b/knowledge-content/index.html
@@ -6,6 +6,7 @@
     <title>Gemini Training & Knowledge Content</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -184,6 +185,7 @@
 </button>
 
     
+    <script src="../shared/announcement.js" defer></script>
 </body>
 </html>
 

--- a/resources/index.html
+++ b/resources/index.html
@@ -6,6 +6,7 @@
     <title>Reusable Templates Library</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         .google-sans { font-family: 'Google Sans', sans-serif; }
@@ -39,6 +40,7 @@
 
     <a href="../index.html" class="hub-button">Back To Hub</a>
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/rpo-training/index.html
+++ b/rpo-training/index.html
@@ -12,6 +12,7 @@
         href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link rel="stylesheet" href="css/style.css">
 </head>
 
@@ -206,6 +207,7 @@
     </button>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 
     <script src="js/app.js"></script>

--- a/rpo-training/manager/index.html
+++ b/rpo-training/manager/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/announcement.css">
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body class="text-gray-800">
@@ -40,6 +41,7 @@
     </section>
   </main>
   <div id="footer-placeholder"></div>
-  <script src="../../shared/scripts/footer.js" defer></script>
+      <script src="../../shared/announcement.js" defer></script>
+    <script src="../../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/rpo-training/recruiter/index.html
+++ b/rpo-training/recruiter/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/announcement.css">
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body class="text-gray-800">
@@ -40,6 +41,7 @@
     </section>
   </main>
   <div id="footer-placeholder"></div>
-  <script src="../../shared/scripts/footer.js" defer></script>
+      <script src="../../shared/announcement.js" defer></script>
+    <script src="../../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/rpo-training/sourcer/index.html
+++ b/rpo-training/sourcer/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/announcement.css">
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body class="text-gray-800">
@@ -40,6 +41,7 @@
     </section>
   </main>
   <div id="footer-placeholder"></div>
-  <script src="../../shared/scripts/footer.js" defer></script>
+      <script src="../../shared/announcement.js" defer></script>
+    <script src="../../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/shared/announcement.css
+++ b/shared/announcement.css
@@ -1,0 +1,7 @@
+.announcement-banner {
+  background-color: #fef3c7; /* amber-100 */
+  color: #92400e; /* amber-800 */
+  padding: 0.75rem 1rem;
+  text-align: center;
+  font-weight: 500;
+}

--- a/shared/announcement.js
+++ b/shared/announcement.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const path = window.location.pathname;
+  const depth = path.split('/').length - 2; // account for leading/trailing slashes
+  const jsonPath = '../'.repeat(depth > 0 ? depth : 0) + 'shared/announcement.json';
+
+  fetch(jsonPath)
+    .then(response => response.json())
+    .then(({ message, expiry }) => {
+      if (!message) return;
+      if (expiry && new Date(expiry) < new Date()) return;
+
+      const banner = document.createElement('div');
+      banner.className = 'announcement-banner';
+      banner.textContent = message;
+      document.body.prepend(banner);
+    })
+    .catch(err => console.error('Error loading announcement:', err));
+});

--- a/shared/announcement.json
+++ b/shared/announcement.json
@@ -1,0 +1,4 @@
+{
+  "message": "This site is currently under development.",
+  "expiry": "2099-12-31T23:59:59Z"
+}

--- a/sourcing-workshop/index.html
+++ b/sourcing-workshop/index.html
@@ -6,6 +6,7 @@
     <title>Sourcing Workshop</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         .google-sans {
@@ -70,6 +71,7 @@
     </div>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 </body>
 </html>

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -6,6 +6,7 @@
     <title>AI Success Stories - Randstad GBS Learning Hub (Fixed)</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         .google-sans { font-family: 'Google Sans', sans-serif; }
@@ -345,6 +346,7 @@
     </div>
 
     <div id="footer-placeholder"></div>
+        <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
 
     <script>

--- a/use-cases/submit.html
+++ b/use-cases/submit.html
@@ -6,6 +6,7 @@
     <title>Submit AI Success Story - Randstad GBS Learning Hub</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         .google-sans { font-family: 'Google Sans', sans-serif; }
@@ -57,5 +58,6 @@
         </form>
     </main>
 
+    <script src="../shared/announcement.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add shared announcement banner script and style
- Provide editable announcement.json for message and expiry
- Load banner on homepage and key subpages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b969afad4c8330b87815ed53a7351f