### PR TITLE
feat: center unified search bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,10 @@
         <header class="text-center mb-12">
             <h1 class="google-sans text-4xl md:text-5xl font-bold text-gray-900">Randstad GBS Learning Hub</h1>
             <p class="mt-4 text-lg text-gray-600 max-w-2xl mx-auto">A central portal for our AI training programs, sourcing tools, and interactive workshops.</p>
+            <div class="relative mt-8 max-w-xl md:max-w-2xl mx-auto">
+                <input type="text" data-search-input placeholder="Search across all modules, content, and resources..." class="w-full border border-gray-300 rounded-full px-6 py-4 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div data-search-results class="absolute left-0 right-0 bg-white border border-gray-200 rounded-md shadow-lg mt-2 max-h-64 overflow-y-auto hidden text-sm"></div>
+            </div>
         </header>
 
         <main>

--- a/shared/navigation.html
+++ b/shared/navigation.html
@@ -1,7 +1,3 @@
-<nav class="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+<nav class="bg-white border-b border-gray-200 px-4 py-3 flex items-center">
   <a href="/index.html" class="font-semibold text-blue-600">Randstad GBS</a>
-  <div class="relative w-full max-w-xs">
-    <input type="text" data-search-input placeholder="Search..." class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm" />
-    <div data-search-results class="absolute left-0 right-0 bg-white border border-gray-200 rounded-md shadow-lg mt-1 max-h-64 overflow-y-auto hidden text-sm"></div>
-  </div>
 </nav>

--- a/shared/scripts/search.js
+++ b/shared/scripts/search.js
@@ -10,7 +10,17 @@ async function buildSearchIndex() {
     { fetch: prefix + 'rpo-training/index.html', url: prefix + 'rpo-training/', category: 'training' },
     { fetch: prefix + 'gbs-ai-workshop/index.html', url: prefix + 'gbs-ai-workshop/', category: 'training' },
     { fetch: prefix + 'daily-focus/index.html', url: prefix + 'daily-focus/', category: 'training' },
-    { fetch: prefix + 'resources/index.html', url: prefix + 'resources/', category: 'resources' }
+    { fetch: prefix + 'sourcing-workshop/index.html', url: prefix + 'sourcing-workshop/', category: 'training' },
+    { fetch: prefix + 'resources/index.html', url: prefix + 'resources/', category: 'resources' },
+    { fetch: prefix + 'gbs-prompts/index.html', url: prefix + 'gbs-prompts/', category: 'content' },
+    { fetch: prefix + 'ai-ethics/index.html', url: prefix + 'ai-ethics/', category: 'content' },
+    { fetch: prefix + 'ai-glossary/index.html', url: prefix + 'ai-glossary/', category: 'content' },
+    { fetch: prefix + 'faq/index.html', url: prefix + 'faq/', category: 'content' },
+    { fetch: prefix + 'ai-sme/index.html', url: prefix + 'ai-sme/', category: 'content' },
+    { fetch: prefix + 'use-cases/index.html', url: prefix + 'use-cases/', category: 'content' },
+    { fetch: prefix + 'knowledge-content/index.html', url: prefix + 'knowledge-content/', category: 'content' },
+    { fetch: prefix + 'events/index.html', url: prefix + 'events/', category: 'content' },
+    { fetch: prefix + 'about-us/index.html', url: prefix + 'about-us/', category: 'content' }
   ];
 
   const docs = [];
@@ -62,8 +72,23 @@ function renderSearchResults(results, container, prefix='') {
     groups[doc.category].push(doc);
   });
 
-  ['training', 'prompts', 'resources'].forEach(cat => {
+  const order = ['training', 'content', 'prompts', 'resources'];
+  order.forEach(cat => {
     if (groups[cat]) {
+      const section = document.createElement('div');
+      section.innerHTML = `<h3 class="font-semibold mt-2 capitalize">${cat}</h3>`;
+      const ul = document.createElement('ul');
+      groups[cat].forEach(doc => {
+        const li = document.createElement('li');
+        li.innerHTML = `<a href="${doc.url}" class="block py-1 text-blue-600 hover:underline"><span class="font-medium">${doc.title}</span><span class="block text-gray-600 text-sm">${doc.description}</span></a>`;
+        ul.appendChild(li);
+      });
+      section.appendChild(ul);
+      container.appendChild(section);
+    }
+  });
+  Object.keys(groups).forEach(cat => {
+    if (!order.includes(cat)) {
       const section = document.createElement('div');
       section.innerHTML = `<h3 class="font-semibold mt-2 capitalize">${cat}</h3>`;
       const ul = document.createElement('ul');


### PR DESCRIPTION
## Summary
- center site-wide search bar on landing page to search modules, content, and resources
- remove navigation search and expand index-building to cover all hub pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b93490ef548330bcece889acce4ace