### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/gbs-prompts/index.html
+++ b/gbs-prompts/index.html
@@ -190,6 +190,41 @@
             background-color: #EF4444;
         }
 
+        /* Dark mode overrides */
+        .dark body {
+            background-color: #1f2937;
+            color: #e5e7eb;
+        }
+
+        .dark .prompt-block {
+            background-color: #1f2937;
+            border-color: #374151;
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -2px rgba(0, 0, 0, 0.5);
+        }
+
+        .dark .prompt-block:hover {
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.6), 0 4px 6px -4px rgba(0, 0, 0, 0.6);
+        }
+
+        .dark .prompt-display-item {
+            background-color: #1f2937;
+            border-color: #374151;
+        }
+
+        .dark .main-heading {
+            color: #f3f4f6;
+        }
+
+        .dark .see-all-btn {
+            border-color: #93c5fd;
+            color: #93c5fd;
+        }
+
+        .dark .see-all-btn:hover {
+            background-color: #93c5fd;
+            color: #1f2937;
+        }
+
         .time-badge {
             display: inline-flex;
             align-items: center;
@@ -462,7 +497,7 @@
     </style>
 </head>
 
-<body class="antialiased">
+<body class="antialiased dark:bg-gray-900 dark:text-gray-100">
 
     <!-- Scroll to Top Button -->
     <button id="scroll-to-top" class="scroll-to-top" title="Scroll to top">

--- a/index.html
+++ b/index.html
@@ -28,85 +28,85 @@
         }
     </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <div id="nav-placeholder"></div>
 
     <div class="container mx-auto px-4 py-12 md:py-20">
 
         <header class="text-center mb-12">
-            <h1 class="google-sans text-4xl md:text-5xl font-bold text-gray-900">Randstad GBS Learning Hub</h1>
-            <p class="mt-4 text-lg text-gray-600 max-w-2xl mx-auto">A central portal for our AI training programs, sourcing tools, and interactive workshops.</p>
+            <h1 class="google-sans text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100">Randstad GBS Learning Hub</h1>
+            <p class="mt-4 text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">A central portal for our AI training programs, sourcing tools, and interactive workshops.</p>
             <div class="relative mt-8 max-w-xl md:max-w-2xl mx-auto">
                 <input type="text" data-search-input placeholder="Search across all modules, content, and resources..." class="w-full border border-gray-300 rounded-full px-6 py-4 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <div data-search-results class="absolute left-0 right-0 bg-white border border-gray-200 rounded-md shadow-lg mt-2 max-h-64 overflow-y-auto hidden text-sm"></div>
+                <div data-search-results class="absolute left-0 right-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg mt-2 max-h-64 overflow-y-auto hidden text-sm"></div>
             </div>
         </header>
 
         <main>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto">
 
-                <a href="/rpo-training/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/rpo-training/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">RPO AI Acceleration Program</h3>
-                    <p class="text-gray-600">The complete, multi-phase training curriculum for all RPO team members, from AI foundations to leadership strategy.</p>
+                    <p class="text-gray-600 dark:text-gray-300">The complete, multi-phase training curriculum for all RPO team members, from AI foundations to leadership strategy.</p>
                 </a>
 
-                <a href="/gbs-ai-workshop/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/gbs-ai-workshop/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">Guide for GBS Leaders</h3>
-                    <p class="text-gray-600">An interactive training for GBS leaders, complete with prompt libraries, simulators, and case studies.</p>
+                    <p class="text-gray-600 dark:text-gray-300">An interactive training for GBS leaders, complete with prompt libraries, simulators, and case studies.</p>
                 </a>
 
-                <a href="/daily-focus/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/daily-focus/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">Daily Sourcing Focus</h3>
-                    <p class="text-gray-600">A daily micro-coaching tool with actionable focus cards designed to sharpen the skills of our talent sourcers.</p>
+                    <p class="text-gray-600 dark:text-gray-300">A daily micro-coaching tool with actionable focus cards designed to sharpen the skills of our talent sourcers.</p>
                 </a>
 
-                <a href="/gbs-prompts/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/gbs-prompts/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">GBS AI Prompts Library</h3>
-                    <p class="text-gray-600">A comprehensive and searchable library of expert prompts designed to accelerate daily tasks for GBS professionals.</p>
+                    <p class="text-gray-600 dark:text-gray-300">A comprehensive and searchable library of expert prompts designed to accelerate daily tasks for GBS professionals.</p>
                 </a>
 
-                <a href="/knowledge-content/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/knowledge-content/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">Knowledge Content</h3>
-                    <p class="text-gray-600">Access a wealth of knowledge content here.</p>
+                    <p class="text-gray-600 dark:text-gray-300">Access a wealth of knowledge content here.</p>
                 </a>
 
-                <a href="/ai-sme/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/ai-sme/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">AI SME</h3>
-                    <p class="text-gray-600">Explore expert AI knowledge and resources.</p>
+                    <p class="text-gray-600 dark:text-gray-300">Explore expert AI knowledge and resources.</p>
                 </a>
-                <a href="/ai-ethics/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/ai-ethics/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">AI Ethics & Compliance</h3>
-                    <p class="text-gray-600">Guidance on data privacy, fairness, and Randstad's AI policies.</p>
+                    <p class="text-gray-600 dark:text-gray-300">Guidance on data privacy, fairness, and Randstad's AI policies.</p>
                 </a>
 
-                <a href="/use-cases/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/use-cases/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">AI Success Stories</h3>
-                    <p class="text-gray-600">Real-world examples and case studies showcasing how AI transforms daily work at Randstad GBS. See the impact firsthand.</p>
+                    <p class="text-gray-600 dark:text-gray-300">Real-world examples and case studies showcasing how AI transforms daily work at Randstad GBS. See the impact firsthand.</p>
                 </a>
 
-                <a href="/sourcing-workshop/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/sourcing-workshop/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">Sourcing Workshop</h3>
-                    <p class="text-gray-600">An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement.</p>
+                    <p class="text-gray-600 dark:text-gray-300">An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement.</p>
                 </a>
 
-                <a href="/ai-glossary/" class="hub-card bg-white p-8 rounded-xl block">
+                <a href="/ai-glossary/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                     <h3 class="google-sans text-2xl font-bold mb-2">AI Glossary</h3>
-                    <p class="text-gray-600">Quick reference of common AI terms and definitions.</p>
+                    <p class="text-gray-600 dark:text-gray-300">Quick reference of common AI terms and definitions.</p>
                 </a>
 
-                  <a href="/faq/" class="hub-card bg-white p-8 rounded-xl block">
+                  <a href="/faq/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                       <h3 class="google-sans text-2xl font-bold mb-2">FAQ</h3>
-                      <p class="text-gray-600">Answers to common AI questions, access issues, and escalation paths.</p>
+                      <p class="text-gray-600 dark:text-gray-300">Answers to common AI questions, access issues, and escalation paths.</p>
                   </a>
 
-                  <a href="/resources/" class="hub-card bg-white p-8 rounded-xl block">
+                  <a href="/resources/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                       <h3 class="google-sans text-2xl font-bold mb-2">Resource Templates</h3>
-                      <p class="text-gray-600">Download reusable documents like sourcing scripts and policy checklists.</p>
+                      <p class="text-gray-600 dark:text-gray-300">Download reusable documents like sourcing scripts and policy checklists.</p>
                   </a>
 
-                  <a href="/events/" class="hub-card bg-white p-8 rounded-xl block">
+                  <a href="/events/" class="hub-card bg-white dark:bg-gray-800 p-8 rounded-xl block">
                       <h3 class="google-sans text-2xl font-bold mb-2">Events &amp; Sessions</h3>
-                      <p class="text-gray-600">View upcoming training dates and register to participate.</p>
+                      <p class="text-gray-600 dark:text-gray-300">View upcoming training dates and register to participate.</p>
                   </a>
 
                 </div>

--- a/shared/navigation.html
+++ b/shared/navigation.html
@@ -1,3 +1,6 @@
-<nav class="bg-white border-b border-gray-200 px-4 py-3 flex items-center">
-  <a href="/index.html" class="font-semibold text-blue-600">Randstad GBS</a>
+<nav class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center justify-between">
+  <a href="/index.html" class="font-semibold text-blue-600 dark:text-blue-400">Randstad GBS</a>
+  <button id="theme-toggle" aria-label="Toggle dark mode" class="p-2 rounded text-gray-600 dark:text-gray-300">
+    <span id="theme-toggle-icon">🌙</span>
+  </button>
 </nav>

--- a/shared/scripts/navigation.js
+++ b/shared/scripts/navigation.js
@@ -1,16 +1,49 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const placeholder = document.getElementById('nav-placeholder');
-  if (!placeholder) return;
-  const path = window.location.pathname;
-  const depth = path.split('/').length - 2;
-  const relativePath = '../'.repeat(depth > 0 ? depth : 0) + 'shared/navigation.html';
-  fetch(relativePath)
-    .then(res => res.text())
-    .then(html => {
-      placeholder.innerHTML = html;
-      if (window.setupSearch) {
-        window.setupSearch();
-      }
-    })
-    .catch(err => console.error('Error loading navigation:', err));
-});
+// Apply stored theme as early as possible
+(function () {
+  const applyTheme = (mode) => {
+    const isDark = mode === 'dark';
+    document.documentElement.classList.toggle('dark', isDark);
+  };
+
+  const initTheme = () => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      applyTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      applyTheme('dark');
+    }
+  };
+
+  initTheme();
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const placeholder = document.getElementById('nav-placeholder');
+    if (!placeholder) return;
+    const path = window.location.pathname;
+    const depth = path.split('/').length - 2;
+    const relativePath = '../'.repeat(depth > 0 ? depth : 0) + 'shared/navigation.html';
+    fetch(relativePath)
+      .then(res => res.text())
+      .then(html => {
+        placeholder.innerHTML = html;
+        const toggle = document.getElementById('theme-toggle');
+        const icon = document.getElementById('theme-toggle-icon');
+        const updateIcon = () => {
+          const isDark = document.documentElement.classList.contains('dark');
+          if (icon) icon.textContent = isDark ? '☀️' : '🌙';
+        };
+        updateIcon();
+        if (toggle) {
+          toggle.addEventListener('click', () => {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            updateIcon();
+          });
+        }
+        if (window.setupSearch) {
+          window.setupSearch();
+        }
+      })
+      .catch(err => console.error('Error loading navigation:', err));
+  });
+})();


### PR DESCRIPTION
## Summary
- add global dark-mode toggle in shared navigation
- persist user preference using localStorage and apply on load
- style home and prompt library pages with dark theme classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99045850483308a3c51a26b4f53a6