### PR TITLE
Add top recruiting prompts section

### DIFF
--- a/gbs-prompts/index.html
+++ b/gbs-prompts/index.html
@@ -500,6 +500,13 @@
                 <button id="tab-favorites" class="px-4 py-2 rounded bg-gray-200 text-gray-700">Favorites</button>
             </div>
         </header>
+        <section id="top-recruiting-prompts" class="container mx-auto px-4 sm:px-6 lg:px-8 mb-12">
+            <h2 class="text-2xl font-bold text-center mb-6">Top Recruiting Prompts</h2>
+            <div id="top-recruiting-prompts-list" class="grid md:grid-cols-2 lg:grid-cols-3 gap-6"></div>
+            <div class="text-center mt-6">
+                <a href="#category-cards-container" class="text-blue-600 hover:underline">Explore 300+ more prompts →</a>
+            </div>
+        </section>
 
         <div id="featured-prompt" class="max-w-xl mx-auto mb-12"></div>
 
@@ -671,6 +678,20 @@
                 const data = await response.json();
                 promptData = data.promptData;
                 flattenPrompts();
+
+                const topRecruitingContainer = document.getElementById('top-recruiting-prompts-list');
+                if (topRecruitingContainer) {
+                    const topRecruitingPrompts = allPrompts
+                        .filter(p => p.category === 'Recruitment' && p.featured)
+                        .slice(0, 5);
+                    topRecruitingContainer.innerHTML = topRecruitingPrompts.map(p => `
+                        <div class="prompt-block p-4">
+                            <h3 class="font-semibold text-lg mb-2">${p.title}</h3>
+                            <p class="text-sm text-gray-600 mb-2">${p.description || ''}</p>
+                            <a href="#" class="text-blue-600 hover:underline text-sm" onclick="openPrompt('${p.id}','${p.category}','${p.subcategory}')">View Prompt →</a>
+                        </div>
+                    `).join('');
+                }
 
                 // Check for a prompt ID in the URL to show it directly
                 const urlParams = new URLSearchParams(window.location.search);

--- a/gbs-prompts/prompts.json
+++ b/gbs-prompts/prompts.json
@@ -8,6 +8,7 @@
           "title": "Understand the Role and Job Market",
           "requiredInputs": ["job role name"],
           "description": "Analyze roles comprehensively including responsibilities, skills, qualifications, and current market trends with salary benchmarks and demand insights.",
+          "featured": true,
           "quickStart": {
             "steps": [
               "Replace [job role] with the specific position you're researching (e.g., 'Senior React Developer')",
@@ -31,6 +32,7 @@
           "title": "Write Job Descriptions",
           "requiredInputs": ["job role", "company values", "specific requirements"],
           "description": "Create compelling, inclusive job descriptions that attract qualified candidates while clearly communicating role expectations and company culture.",
+          "featured": true,
           "quickStart": {
             "steps": [
               "Gather: job title, key responsibilities, required skills, and company culture info",
@@ -56,6 +58,7 @@
           "title": "Analyze and Find Potential Gaps in Resumes",
           "requiredInputs": ["resume content", "job requirements"],
           "description": "Identify resume inconsistencies, employment gaps, and potential red flags to prepare targeted interview questions and assessments.",
+          "featured": true,
           "quickStart": {
             "steps": [
               "Have the candidate's resume ready to review",
@@ -79,6 +82,7 @@
           "title": "Come Up With Interview Questions",
           "requiredInputs": ["job role", "key competencies"],
           "description": "Develop comprehensive interview questions that assess technical skills, soft skills, and cultural fit while ensuring legal compliance.",
+          "featured": true,
           "quickStart": {
             "steps": [
               "Identify the [job role] you're hiring for",
@@ -103,6 +107,7 @@
           "title": "Draft an Email to a Potential Candidate",
           "requiredInputs": ["candidate name", "job role", "next steps"],
           "description": "Compose professional, welcoming candidate communications that outline next steps and create positive first impressions of your organization.",
+          "featured": true,
           "quickStart": {
             "steps": [
               "Replace [name] with the candidate's actual name",


### PR DESCRIPTION
## Summary
- Add top recruiting prompts section and display top featured recruiting prompts
- Filter prompts to five featured recruitment items and render compact cards
- Add `featured` flag to recruitment prompts for easier curation

## Testing
- `python -m json.tool gbs-prompts/prompts.json | head -n 5`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99e5e0aa08330af6f88fd77f111a9