### PR TITLE
refactor: move About page styles to external CSS

### DIFF
--- a/about-us/about.css
+++ b/about-us/about.css
@@ -1,0 +1,46 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: #F8F7F4; /* Soft off-white background */
+    color: #4A4A4A; /* Dark gray text */
+}
+
+.accent-text {
+    color: #2C5282; /* Professional and energetic blue */
+}
+
+.main-heading {
+    color: #111827; /* Darker text for main headings */
+}
+
+.nav-link {
+    transition: color 0.3s ease;
+}
+
+.nav-link:hover {
+    color: #2C5282;
+}
+
+.content-card {
+    background-color: #FFFFFF;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+}
+
+.fade-in {
+    animation: fadeIn 1s ease-in-out;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+

--- a/about-us/index.html
+++ b/about-us/index.html
@@ -7,39 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
     <link rel="stylesheet" href="../shared/announcement.css">
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #F8F7F4; /* Soft off-white background */
-            color: #4A4A4A; /* Dark gray text */
-        }
-        .accent-text {
-            color: #2C5282; /* Professional and energetic blue */
-        }
-        .main-heading {
-             color: #111827; /* Darker text for main headings */
-        }
-        .nav-link {
-            transition: color 0.3s ease;
-        }
-        .nav-link:hover {
-            color: #2C5282;
-        }
-        .content-card {
-            background-color: #FFFFFF;
-            border: 1px solid #e5e7eb;
-            border-radius: 0.75rem;
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
-        }
-        .fade-in {
-            animation: fadeIn 1s ease-in-out;
-        }
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(20px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-    </style>
+    <link rel="stylesheet" href="about.css">
 </head>
 <body class="antialiased">
 


### PR DESCRIPTION
## Summary
- extract inline styles from About page into `about-us/about.css`
- link new stylesheet and delete inline style block

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a9403ce483308b2d66e1790222cb