### PR TITLE
Load hub cards from config

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,73 +43,7 @@
         </header>
 
         <main>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto">
-
-                <a href="/rpo-training/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">RPO AI Acceleration Program</h3>
-                    <p class="text-gray-600">The complete, multi-phase training curriculum for all RPO team members, from AI foundations to leadership strategy.</p>
-                </a>
-
-                <a href="/gbs-ai-workshop/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">Guide for GBS Leaders</h3>
-                    <p class="text-gray-600">An interactive training for GBS leaders, complete with prompt libraries, simulators, and case studies.</p>
-                </a>
-
-                <a href="/daily-focus/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">Daily Sourcing Focus</h3>
-                    <p class="text-gray-600">A daily micro-coaching tool with actionable focus cards designed to sharpen the skills of our talent sourcers.</p>
-                </a>
-
-                <a href="/gbs-prompts/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">GBS AI Prompts Library</h3>
-                    <p class="text-gray-600">A comprehensive and searchable library of expert prompts designed to accelerate daily tasks for GBS professionals.</p>
-                </a>
-
-                <a href="/knowledge-content/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">Knowledge Content</h3>
-                    <p class="text-gray-600">Access a wealth of knowledge content here.</p>
-                </a>
-
-                <a href="/ai-sme/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">AI SME</h3>
-                    <p class="text-gray-600">Explore expert AI knowledge and resources.</p>
-                </a>
-                <a href="/ai-ethics/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">AI Ethics & Compliance</h3>
-                    <p class="text-gray-600">Guidance on data privacy, fairness, and Randstad's AI policies.</p>
-                </a>
-
-                <a href="/use-cases/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">AI Success Stories</h3>
-                    <p class="text-gray-600">Real-world examples and case studies showcasing how AI transforms daily work at Randstad GBS. See the impact firsthand.</p>
-                </a>
-
-                <a href="/sourcing-workshop/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">Sourcing Workshop</h3>
-                    <p class="text-gray-600">An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement.</p>
-                </a>
-
-                <a href="/ai-glossary/" class="hub-card bg-white p-8 rounded-xl block">
-                    <h3 class="google-sans text-2xl font-bold mb-2">AI Glossary</h3>
-                    <p class="text-gray-600">Quick reference of common AI terms and definitions.</p>
-                </a>
-
-                  <a href="/faq/" class="hub-card bg-white p-8 rounded-xl block">
-                      <h3 class="google-sans text-2xl font-bold mb-2">FAQ</h3>
-                      <p class="text-gray-600">Answers to common AI questions, access issues, and escalation paths.</p>
-                  </a>
-
-                  <a href="/resources/" class="hub-card bg-white p-8 rounded-xl block">
-                      <h3 class="google-sans text-2xl font-bold mb-2">Resource Templates</h3>
-                      <p class="text-gray-600">Download reusable documents like sourcing scripts and policy checklists.</p>
-                  </a>
-
-                  <a href="/events/" class="hub-card bg-white p-8 rounded-xl block">
-                      <h3 class="google-sans text-2xl font-bold mb-2">Events &amp; Sessions</h3>
-                      <p class="text-gray-600">View upcoming training dates and register to participate.</p>
-                  </a>
-
-                </div>
+            <div id="hub-sections" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto"></div>
         </main>
     </div>
 
@@ -117,6 +51,7 @@
     <script src="https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js"></script>
     <script src="shared/scripts/search.js" defer></script>
     <script src="shared/scripts/navigation.js" defer></script>
+    <script src="shared/scripts/sections.js" defer></script>
     <script src="shared/announcement.js" defer></script>
     <script src="shared/scripts/footer.js" defer></script>
 </body>

--- a/shared/config/sections.json
+++ b/shared/config/sections.json
@@ -1,0 +1,67 @@
+[
+  {
+    "title": "RPO AI Acceleration Program",
+    "description": "The complete, multi-phase training curriculum for all RPO team members, from AI foundations to leadership strategy.",
+    "url": "/rpo-training/"
+  },
+  {
+    "title": "Guide for GBS Leaders",
+    "description": "An interactive training for GBS leaders, complete with prompt libraries, simulators, and case studies.",
+    "url": "/gbs-ai-workshop/"
+  },
+  {
+    "title": "Daily Sourcing Focus",
+    "description": "A daily micro-coaching tool with actionable focus cards designed to sharpen the skills of our talent sourcers.",
+    "url": "/daily-focus/"
+  },
+  {
+    "title": "GBS AI Prompts Library",
+    "description": "A comprehensive and searchable library of expert prompts designed to accelerate daily tasks for GBS professionals.",
+    "url": "/gbs-prompts/"
+  },
+  {
+    "title": "Knowledge Content",
+    "description": "Access a wealth of knowledge content here.",
+    "url": "/knowledge-content/"
+  },
+  {
+    "title": "AI SME",
+    "description": "Explore expert AI knowledge and resources.",
+    "url": "/ai-sme/"
+  },
+  {
+    "title": "AI Ethics & Compliance",
+    "description": "Guidance on data privacy, fairness, and Randstad's AI policies.",
+    "url": "/ai-ethics/"
+  },
+  {
+    "title": "AI Success Stories",
+    "description": "Real-world examples and case studies showcasing how AI transforms daily work at Randstad GBS. See the impact firsthand.",
+    "url": "/use-cases/"
+  },
+  {
+    "title": "Sourcing Workshop",
+    "description": "An in-depth workshop dedicated to advanced sourcing techniques, market intelligence, and candidate engagement.",
+    "url": "/sourcing-workshop/"
+  },
+  {
+    "title": "AI Glossary",
+    "description": "Quick reference of common AI terms and definitions.",
+    "url": "/ai-glossary/"
+  },
+  {
+    "title": "FAQ",
+    "description": "Answers to common AI questions, access issues, and escalation paths.",
+    "url": "/faq/"
+  },
+  {
+    "title": "Resource Templates",
+    "description": "Download reusable documents like sourcing scripts and policy checklists.",
+    "url": "/resources/"
+  },
+  {
+    "title": "Events & Sessions",
+    "description": "View upcoming training dates and register to participate.",
+    "url": "/events/"
+  }
+]

--- a/shared/scripts/sections.js
+++ b/shared/scripts/sections.js
@@ -1,0 +1,25 @@
+// Dynamically render hub cards on the index page
+// Runs after navigation and search scripts (loaded after them with defer)
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('hub-sections');
+  if (!container) return;
+
+  fetch('/shared/config/sections.json')
+    .then(response => {
+      if (!response.ok) throw new Error('Failed to load sections.json');
+      return response.json();
+    })
+    .then(sections => {
+      sections.forEach(section => {
+        const link = document.createElement('a');
+        link.href = section.url;
+        link.className = 'hub-card bg-white p-8 rounded-xl block';
+        link.innerHTML = `
+          <h3 class="google-sans text-2xl font-bold mb-2">${section.title}</h3>
+          <p class="text-gray-600">${section.description}</p>
+        `;
+        container.appendChild(link);
+      });
+    })
+    .catch(error => console.error('Error loading sections:', error));
+});


### PR DESCRIPTION
## Summary
- Define hub card metadata in `shared/config/sections.json`
- Render index cards dynamically with new `shared/scripts/sections.js`
- Replace hard-coded links in `index.html` with container and script hook

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node scripts/build-search-index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9a9aef3708330a0900df7aa88f860