### PR TITLE
Add Back To Hub button to AI SME pages

### DIFF
--- a/ai-sme/index.html
+++ b/ai-sme/index.html
@@ -95,9 +95,12 @@
             font-size: 1.125rem;
         }
     </style>
+    <link rel="stylesheet" href="../shared/hub-button.css">
     <link rel="stylesheet" href="../shared/announcement.css">
 </head>
 <body class="bg-brand-bg text-brand-body font-sans leading-relaxed">
+
+    <a href="../index.html" class="hub-button">Back To Hub</a>
 
     <!-- Header & Navigation -->
     <header id="header" class="bg-white/80 backdrop-blur-sm sticky top-0 z-50 transition-all duration-300 shadow-sm">

--- a/ai-sme/new-page-template.html
+++ b/ai-sme/new-page-template.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <!-- Link to the shared color palette -->
+    <link rel="stylesheet" href="../shared/hub-button.css">
     <link rel="stylesheet" href="../../shared/ai-sme-colors.css">
     <script>
         // Tailwind config using the new CSS variables
@@ -40,6 +41,8 @@
     </style>
 </head>
 <body class="bg-brand-bg text-brand-body font-sans leading-relaxed">
+
+    <a href="../index.html" class="hub-button">Back To Hub</a>
 
     <!-- Header & Navigation (Consistent with index.html) -->
     <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-50 transition-all duration-300 shadow-sm">


### PR DESCRIPTION
## Summary
- Add Back To Hub button to AI SME pages and template
- Include shared hub-button styling for consistent appearance

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9aa5e8ba883308be958d7e54e10e9