### PR TITLE
refactor: move prompt styles to separate css

### DIFF
--- a/gbs-prompts/index.html
+++ b/gbs-prompts/index.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../shared/hub-button.css">
     <link rel="stylesheet" href="../shared/announcement.css">
+    <link rel="stylesheet" href="prompts.css">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
@@ -17,39 +18,6 @@
             /* Soft off-white background */
             color: #4A4A4A;
             /* Dark gray text used across the site */
-        }
-
-        /* --- Custom Scrollbar for lists --- */
-        .scrollable-list::-webkit-scrollbar {
-            width: 6px;
-        }
-
-        .scrollable-list::-webkit-scrollbar-track {
-            background: #f1f5f9;
-            border-radius: 10px;
-        }
-
-        .scrollable-list::-webkit-scrollbar-thumb {
-            background: #cbd5e1;
-            border-radius: 10px;
-        }
-
-        .scrollable-list::-webkit-scrollbar-thumb:hover {
-            background: #94a3b8;
-        }
-
-        /* --- General Card Style with Hover Animation --- */
-        .prompt-block {
-            border: 1px solid #e5e7eb;
-            border-radius: 0.75rem;
-            background-color: #FFFFFF;
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
-
-        .prompt-block:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.07), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
         }
 
         /* --- Homepage Category Card --- */

--- a/gbs-prompts/prompts.css
+++ b/gbs-prompts/prompts.css
@@ -1,0 +1,32 @@
+/* --- Custom Scrollbar for lists --- */
+.scrollable-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.scrollable-list::-webkit-scrollbar-track {
+    background: #f1f5f9;
+    border-radius: 10px;
+}
+
+.scrollable-list::-webkit-scrollbar-thumb {
+    background: #cbd5e1;
+    border-radius: 10px;
+}
+
+.scrollable-list::-webkit-scrollbar-thumb:hover {
+    background: #94a3b8;
+}
+
+/* --- General Card Style with Hover Animation --- */
+.prompt-block {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    background-color: #FFFFFF;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.prompt-block:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.07), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}


### PR DESCRIPTION
## Summary
- Extract scrollable list and prompt card styles from inline `<style>` to new `gbs-prompts/prompts.css`
- Import the new stylesheet in the prompt library's `<head>` for reuse

## Testing
- `node scripts/build-search-index.js`
- `node -e "const fs=require('fs'); fs.readFile('gbs-prompts/prompts.json','utf8',(err,data)=>{if(err) throw err; const j=JSON.parse(data); console.log(Object.keys(j));});"`


------
https://chatgpt.com/codex/tasks/task_e_68b9db81d3508330bfc8bcd15a9d7ca8