### PR TITLE
Build glossary from JSON

### DIFF
--- a/ai-glossary/glossary.js
+++ b/ai-glossary/glossary.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const response = await fetch('terms.json');
+    const data = await response.json();
+
+    const nav = document.getElementById('alphabet-nav');
+    const main = document.getElementById('glossary-content');
+
+    const letters = Object.keys(data).sort();
+
+    letters.forEach(letter => {
+      const link = document.createElement('a');
+      link.href = `#${letter}`;
+      link.textContent = letter;
+      link.className = 'text-blue-600 hover:underline';
+      nav.appendChild(link);
+    });
+
+    letters.forEach(letter => {
+      const section = document.createElement('section');
+      section.id = letter;
+
+      const heading = document.createElement('h2');
+      heading.className = 'google-sans text-2xl font-semibold mb-4';
+      heading.textContent = letter;
+      section.appendChild(heading);
+
+      const dl = document.createElement('dl');
+      data[letter].forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'mb-4';
+
+        const dt = document.createElement('dt');
+        dt.className = 'font-bold';
+        dt.textContent = item.term;
+        div.appendChild(dt);
+
+        const dd = document.createElement('dd');
+        dd.className = 'text-gray-700';
+        dd.textContent = item.definition;
+        div.appendChild(dd);
+
+        dl.appendChild(div);
+      });
+      section.appendChild(dl);
+      main.appendChild(section);
+    });
+  } catch (e) {
+    console.error('Failed to load glossary terms', e);
+  }
+});

--- a/ai-glossary/index.html
+++ b/ai-glossary/index.html
@@ -24,84 +24,14 @@
             <p class="text-gray-600">Alphabetical reference for common AI terms.</p>
         </header>
 
-        <nav class="flex flex-wrap gap-2 justify-center mb-8">
-            <a href="#A" class="text-blue-600 hover:underline">A</a>
-            <a href="#B" class="text-blue-600 hover:underline">B</a>
-            <a href="#D" class="text-blue-600 hover:underline">D</a>
-            <a href="#M" class="text-blue-600 hover:underline">M</a>
-            <a href="#N" class="text-blue-600 hover:underline">N</a>
-            <a href="#P" class="text-blue-600 hover:underline">P</a>
-        </nav>
+        <nav id="alphabet-nav" class="flex flex-wrap gap-2 justify-center mb-8"></nav>
 
-        <main class="space-y-8">
-            <section id="A">
-                <h2 class="google-sans text-2xl font-semibold mb-4">A</h2>
-                <dl>
-                    <div class="mb-4">
-                        <dt class="font-bold">Algorithm</dt>
-                        <dd class="text-gray-700">A set of rules or instructions a computer follows to solve a problem or complete a task.</dd>
-                    </div>
-                    <div class="mb-4">
-                        <dt class="font-bold">Artificial Intelligence (AI)</dt>
-                        <dd class="text-gray-700">The field of creating systems that can perform tasks typically requiring human intelligence.</dd>
-                    </div>
-                </dl>
-            </section>
-
-            <section id="B">
-                <h2 class="google-sans text-2xl font-semibold mb-4">B</h2>
-                <dl>
-                    <div class="mb-4">
-                        <dt class="font-bold">Bias</dt>
-                        <dd class="text-gray-700">Systematic errors that lead to unfair outcomes, often reflecting prejudices in training data.</dd>
-                    </div>
-                </dl>
-            </section>
-
-            <section id="D">
-                <h2 class="google-sans text-2xl font-semibold mb-4">D</h2>
-                <dl>
-                    <div class="mb-4">
-                        <dt class="font-bold">Dataset</dt>
-                        <dd class="text-gray-700">A collection of data used to train or evaluate AI models.</dd>
-                    </div>
-                </dl>
-            </section>
-
-            <section id="M">
-                <h2 class="google-sans text-2xl font-semibold mb-4">M</h2>
-                <dl>
-                    <div class="mb-4">
-                        <dt class="font-bold">Machine Learning (ML)</dt>
-                        <dd class="text-gray-700">A subset of AI that enables systems to learn from data and improve over time without being explicitly programmed.</dd>
-                    </div>
-                </dl>
-            </section>
-
-            <section id="N">
-                <h2 class="google-sans text-2xl font-semibold mb-4">N</h2>
-                <dl>
-                    <div class="mb-4">
-                        <dt class="font-bold">Neural Network</dt>
-                        <dd class="text-gray-700">A network of algorithms modeled after the human brain, used to recognize patterns and solve complex problems.</dd>
-                    </div>
-                </dl>
-            </section>
-
-            <section id="P">
-                <h2 class="google-sans text-2xl font-semibold mb-4">P</h2>
-                <dl>
-                    <div class="mb-4">
-                        <dt class="font-bold">Prompt</dt>
-                        <dd class="text-gray-700">A textual or structured input that guides an AI model to generate a specific output.</dd>
-                    </div>
-                </dl>
-            </section>
-        </main>
+        <main id="glossary-content" class="space-y-8"></main>
     </div>
 
     <div id="footer-placeholder"></div>
-        <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
+    <script src="glossary.js" defer></script>
 </body>
 </html>

--- a/ai-glossary/terms.json
+++ b/ai-glossary/terms.json
@@ -1,0 +1,21 @@
+{
+  "A": [
+    {"term": "Algorithm", "definition": "A set of rules or instructions a computer follows to solve a problem or complete a task."},
+    {"term": "Artificial Intelligence (AI)", "definition": "The field of creating systems that can perform tasks typically requiring human intelligence."}
+  ],
+  "B": [
+    {"term": "Bias", "definition": "Systematic errors that lead to unfair outcomes, often reflecting prejudices in training data."}
+  ],
+  "D": [
+    {"term": "Dataset", "definition": "A collection of data used to train or evaluate AI models."}
+  ],
+  "M": [
+    {"term": "Machine Learning (ML)", "definition": "A subset of AI that enables systems to learn from data and improve over time without being explicitly programmed."}
+  ],
+  "N": [
+    {"term": "Neural Network", "definition": "A network of algorithms modeled after the human brain, used to recognize patterns and solve complex problems."}
+  ],
+  "P": [
+    {"term": "Prompt", "definition": "A textual or structured input that guides an AI model to generate a specific output."}
+  ]
+}


### PR DESCRIPTION
## Summary
- move AI glossary terms into `terms.json` grouped by initial letter
- generate navigation and sections from JSON with `glossary.js`
- simplify glossary `index.html` to load terms dynamically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0012c488330b8caf0dbb9850e33