### PR TITLE
Render sourcing workshop sections from JSON

### DIFF
--- a/sourcing-workshop/content.json
+++ b/sourcing-workshop/content.json
@@ -1,0 +1,44 @@
+{
+  "marketIntelligence": {
+    "lessons": [
+      "Identify relevant data sources",
+      "Analyze supply and demand trends",
+      "Develop target candidate profiles"
+    ],
+    "exercises": [
+      "Use a market report to map three emerging talent hubs.",
+      "Create a brief comparing competitor hiring trends."
+    ],
+    "resources": [
+      {
+        "text": "Gartner: Talent Intelligence",
+        "url": "https://www.gartner.com/en/human-resources/insights/talent-intelligence"
+      },
+      {
+        "text": "LinkedIn Talent Blog",
+        "url": "https://www.linkedin.com/talent/blog"
+      }
+    ]
+  },
+  "engagementTactics": {
+    "lessons": [
+      "Craft personalized outreach messages",
+      "A/B test subject lines and calls to action",
+      "Design follow-up cadences"
+    ],
+    "exercises": [
+      "Draft a cold outreach message for a niche role.",
+      "Experiment with two follow-up templates and compare response rates."
+    ],
+    "resources": [
+      {
+        "text": "HireRabbit Sourcing Tips",
+        "url": "https://www.hirerabbit.com/blog/sourcing-candidates/"
+      },
+      {
+        "text": "RecruitingDaily: Sourcing Articles",
+        "url": "https://www.recruitingdaily.com/category/sourcing/"
+      }
+    ]
+  }
+}

--- a/sourcing-workshop/index.html
+++ b/sourcing-workshop/index.html
@@ -27,51 +27,14 @@
             </nav>
         </header>
 
-        <section id="market-intelligence" class="mb-12">
-            <h2 class="google-sans text-2xl font-bold mb-2">Market Intelligence</h2>
-            <p class="mb-4">Explore how to gather and interpret labor market data to target sourcing efforts effectively.</p>
-            <h3 class="font-semibold mb-2">Lesson Structure</h3>
-            <ul class="list-disc list-inside mb-4">
-                <li>Identify relevant data sources</li>
-                <li>Analyze supply and demand trends</li>
-                <li>Develop target candidate profiles</li>
-            </ul>
-            <h3 class="font-semibold mb-2">Exercises</h3>
-            <ul class="list-disc list-inside mb-4">
-                <li>Use a market report to map three emerging talent hubs.</li>
-                <li>Create a brief comparing competitor hiring trends.</li>
-            </ul>
-            <h3 class="font-semibold mb-2">Resources</h3>
-            <ul class="list-disc list-inside">
-                <li><a href="https://www.gartner.com/en/human-resources/insights/talent-intelligence" class="text-blue-600 hover:underline">Gartner: Talent Intelligence</a></li>
-                <li><a href="https://www.linkedin.com/talent/blog" class="text-blue-600 hover:underline">LinkedIn Talent Blog</a></li>
-            </ul>
-        </section>
+        <section id="market-intelligence" class="mb-12"></section>
 
-        <section id="engagement-tactics" class="mb-12">
-            <h2 class="google-sans text-2xl font-bold mb-2">Engagement Tactics</h2>
-            <p class="mb-4">Learn approaches for connecting with candidates and building lasting relationships.</p>
-            <h3 class="font-semibold mb-2">Lesson Structure</h3>
-            <ul class="list-disc list-inside mb-4">
-                <li>Craft personalized outreach messages</li>
-                <li>A/B test subject lines and calls to action</li>
-                <li>Design follow-up cadences</li>
-            </ul>
-            <h3 class="font-semibold mb-2">Exercises</h3>
-            <ul class="list-disc list-inside mb-4">
-                <li>Draft a cold outreach message for a niche role.</li>
-                <li>Experiment with two follow-up templates and compare response rates.</li>
-            </ul>
-            <h3 class="font-semibold mb-2">Resources</h3>
-            <ul class="list-disc list-inside">
-                <li><a href="https://www.hirerabbit.com/blog/sourcing-candidates/" class="text-blue-600 hover:underline">HireRabbit Sourcing Tips</a></li>
-                <li><a href="https://www.recruitingdaily.com/category/sourcing/" class="text-blue-600 hover:underline">RecruitingDaily: Sourcing Articles</a></li>
-            </ul>
-        </section>
+        <section id="engagement-tactics" class="mb-12"></section>
     </div>
 
     <div id="footer-placeholder"></div>
         <script src="../shared/announcement.js" defer></script>
     <script src="../shared/scripts/footer.js" defer></script>
+    <script src="script.js" defer></script>
 </body>
 </html>

--- a/sourcing-workshop/script.js
+++ b/sourcing-workshop/script.js
@@ -1,0 +1,50 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const response = await fetch('content.json');
+    const data = await response.json();
+    renderSection(
+      'market-intelligence',
+      data.marketIntelligence,
+      'Market Intelligence',
+      'Explore how to gather and interpret labor market data to target sourcing efforts effectively.'
+    );
+    renderSection(
+      'engagement-tactics',
+      data.engagementTactics,
+      'Engagement Tactics',
+      'Learn approaches for connecting with candidates and building lasting relationships.'
+    );
+  } catch (error) {
+    console.error('Error loading workshop content:', error);
+  }
+});
+
+function renderSection(id, content, title, description) {
+  const section = document.getElementById(id);
+  if (!section) return;
+  section.innerHTML = `
+    <h2 class="google-sans text-2xl font-bold mb-2">${title}</h2>
+    <p class="mb-4">${description}</p>
+    ${renderList('Lesson Structure', content.lessons)}
+    ${renderList('Exercises', content.exercises)}
+    ${renderResources('Resources', content.resources)}
+  `;
+}
+
+function renderList(heading, items) {
+  const lis = items.map(item => `<li>${item}</li>`).join('');
+  return `
+    <h3 class="font-semibold mb-2">${heading}</h3>
+    <ul class="list-disc list-inside mb-4">${lis}</ul>
+  `;
+}
+
+function renderResources(heading, items) {
+  const lis = items
+    .map(r => `<li><a href="${r.url}" class="text-blue-600 hover:underline">${r.text}</a></li>`)
+    .join('');
+  return `
+    <h3 class="font-semibold mb-2">${heading}</h3>
+    <ul class="list-disc list-inside">${lis}</ul>
+  `;
+}


### PR DESCRIPTION
## Summary
- Load Sourcing Workshop details from new JSON data file
- Render Market Intelligence and Engagement Tactics sections via client-side script
- Keep existing anchor links for navigation

## Testing
- `npx --yes htmlhint sourcing-workshop/index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e31d23b08330bb2ad33f00a0fb4b