### PR TITLE
Add role-based dashboard and redirect

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dashboard | Randstad GBS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../shared/hub-button.css" />
+  <link rel="stylesheet" href="../shared/announcement.css" />
+  <link rel="stylesheet" href="../style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <div id="nav-placeholder"></div>
+
+  <main class="container mx-auto px-4 py-12 md:py-20">
+    <header class="text-center mb-12">
+      <h1 class="google-sans text-4xl md:text-5xl font-bold text-gray-900">Your Dashboard</h1>
+      <p class="mt-4 text-lg text-gray-600 max-w-2xl mx-auto">Select your role to view relevant sections.</p>
+    </header>
+
+    <section id="role-selection" class="text-center mb-12">
+      <label for="role-selector" class="mr-4 font-medium">Choose your role:</label>
+      <select id="role-selector" class="border border-gray-300 rounded-md px-4 py-2">
+        <option value="">--Select Role--</option>
+        <option value="rpo">RPO</option>
+        <option value="msp">MSP</option>
+        <option value="admin">Admin</option>
+      </select>
+      <button id="save-role" class="ml-4 px-4 py-2 bg-blue-500 text-white rounded-md">Go</button>
+    </section>
+
+    <div id="dashboard-sections" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto"></div>
+  </main>
+
+  <div id="footer-placeholder"></div>
+  <script src="../shared/announcement.js" defer></script>
+  <script src="../shared/scripts/navigation.js" defer></script>
+  <script src="../shared/scripts/footer.js" defer></script>
+  <script src="../shared/scripts/dashboard.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Randstad GBS - AI Hub</title>
+    <script>if(localStorage.getItem('userRole')){window.location.href='dashboard/';}</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="shared/hub-button.css">
     <link rel="stylesheet" href="shared/announcement.css">

--- a/shared/scripts/dashboard.js
+++ b/shared/scripts/dashboard.js
@@ -1,0 +1,52 @@
+// Handle role selection and dashboard sections
+
+document.addEventListener('DOMContentLoaded', () => {
+  const selector = document.getElementById('role-selector');
+  const saveBtn = document.getElementById('save-role');
+  const sectionsContainer = document.getElementById('dashboard-sections');
+
+  const roleSections = {
+    rpo: [
+      { title: 'RPO Training', description: 'Training curriculum for RPO teams.', url: '/rpo-training/' },
+      { title: 'Sourcing Workshop', description: 'Interactive sourcing workshop.', url: '/sourcing-workshop/' }
+    ],
+    msp: [
+      { title: 'GBS AI Workshop', description: 'AI workshop resources for MSP.', url: '/gbs-ai-workshop/' },
+      { title: 'Resources', description: 'General resources and guides.', url: '/resources/' }
+    ],
+    admin: [
+      { title: 'Feedback', description: 'View user feedback submissions.', url: '/feedback/' },
+      { title: 'Knowledge Content', description: 'Manage knowledge base materials.', url: '/knowledge-content/' }
+    ]
+  };
+
+  function renderSections(role) {
+    if (!sectionsContainer || !roleSections[role]) return;
+    sectionsContainer.innerHTML = '';
+    roleSections[role].forEach(section => {
+      const link = document.createElement('a');
+      link.href = section.url;
+      link.className = 'hub-card bg-white p-8 rounded-xl block';
+      link.innerHTML = `
+        <h3 class="google-sans text-2xl font-bold mb-2">${section.title}</h3>
+        <p class="text-gray-600">${section.description}</p>
+      `;
+      sectionsContainer.appendChild(link);
+    });
+  }
+
+  const storedRole = localStorage.getItem('userRole');
+  if (storedRole && selector) {
+    selector.value = storedRole;
+    renderSections(storedRole);
+  }
+
+  if (saveBtn && selector) {
+    saveBtn.addEventListener('click', () => {
+      const role = selector.value;
+      if (!role) return;
+      localStorage.setItem('userRole', role);
+      renderSections(role);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add `/dashboard/index.html` with role selector for RPO, MSP, and Admin roles
- load role-specific sections and store chosen role via new `dashboard.js`
- redirect returning users with a saved role to their dashboard from the home page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e63b183c8330a01700fc3bb7f7f4