### PR TITLE
feat: add business unit filtering for use cases

### DIFF
--- a/use-cases/cases.js
+++ b/use-cases/cases.js
@@ -149,7 +149,7 @@ Requirements:
 }
 
 // Filter functionality (no inline 'event' usage)
-function filterCases(category, targetButton) {
+function filterCases(filter, targetButton) {
     const cases = document.querySelectorAll('.case-item');
     const filters = document.querySelectorAll('.category-filter');
 
@@ -157,7 +157,11 @@ function filterCases(category, targetButton) {
     if (targetButton) targetButton.classList.add('active');
 
     cases.forEach(c => {
-        if (category === 'all' || c.dataset.category === category) {
+        if (
+            filter === 'all' ||
+            c.dataset.category === filter ||
+            c.dataset.unit === filter
+        ) {
             c.style.display = '';
         } else {
             c.style.display = 'none';
@@ -170,6 +174,8 @@ async function loadCases() {
     const data = await res.json();
     const categoriesMap = {};
     data.categories.forEach(c => { categoriesMap[c.id] = c.label; });
+    const unitsMap = {};
+    data.businessUnits.forEach(u => { unitsMap[u.id] = u.label; });
 
     const filtersEl = document.getElementById('filters');
     const allBtn = document.createElement('button');
@@ -186,14 +192,22 @@ async function loadCases() {
         filtersEl.appendChild(btn);
     });
 
+    data.businessUnits.forEach(unit => {
+        const btn = document.createElement('button');
+        btn.dataset.filter = unit.id;
+        btn.className = 'category-filter px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200';
+        btn.textContent = unit.label;
+        filtersEl.appendChild(btn);
+    });
+
     const container = document.getElementById('cases-container');
-    data.cases.forEach(c => container.appendChild(buildCaseCard(c, categoriesMap)));
+    data.cases.forEach(c => container.appendChild(buildCaseCard(c, categoriesMap, unitsMap)));
 
     const filterButtons = document.querySelectorAll('#filters .category-filter');
     filterButtons.forEach(btn => {
         btn.addEventListener('click', () => {
-            const cat = btn.dataset.filter || 'all';
-            filterCases(cat, btn);
+            const f = btn.dataset.filter || 'all';
+            filterCases(f, btn);
         });
     });
 
@@ -206,23 +220,33 @@ async function loadCases() {
     });
 }
 
-function buildCaseCard(data, categoriesMap) {
+function buildCaseCard(data, categoriesMap, unitsMap) {
     const card = document.createElement('div');
     card.className = 'use-case-card p-8 rounded-xl case-item';
     card.dataset.category = data.category;
+    card.dataset.unit = data.businessUnit;
 
     const top = document.createElement('div');
     top.className = 'flex items-center justify-between mb-4';
+
+    const badges = document.createElement('div');
+    badges.className = 'flex gap-2';
 
     const catBadge = document.createElement('span');
     catBadge.className = 'category-badge px-3 py-1 rounded-full text-xs font-semibold';
     catBadge.textContent = categoriesMap[data.category] || data.category;
 
+    const unitBadge = document.createElement('span');
+    unitBadge.className = 'category-badge px-3 py-1 rounded-full text-xs font-semibold';
+    unitBadge.textContent = unitsMap[data.businessUnit] || data.businessUnit;
+
+    badges.append(catBadge, unitBadge);
+
     const impact = document.createElement('span');
     impact.className = 'text-green-600 font-semibold';
     impact.textContent = data.impact;
 
-    top.append(catBadge, impact);
+    top.append(badges, impact);
     card.appendChild(top);
 
     const title = document.createElement('h3');

--- a/use-cases/cases.json
+++ b/use-cases/cases.json
@@ -5,10 +5,16 @@
     { "id": "analysis", "label": "Data Analysis" },
     { "id": "communication", "label": "Communication" }
   ],
+  "businessUnits": [
+    { "id": "gbs", "label": "GBS" },
+    { "id": "rpo", "label": "RPO" },
+    { "id": "msp", "label": "MSP" }
+  ],
   "cases": [
     {
       "id": "boolean-search",
       "category": "sourcing",
+      "businessUnit": "rpo",
       "impact": "75% Time Saved",
       "title": "AI-Powered Boolean Search Generation",
       "before": [
@@ -33,6 +39,7 @@
     {
       "id": "jd-writing",
       "category": "content",
+      "businessUnit": "rpo",
       "impact": "80% Faster",
       "title": "Intelligent Job Description Creation",
       "before": [
@@ -56,6 +63,7 @@
     {
       "id": "candidate-outreach",
       "category": "communication",
+      "businessUnit": "rpo",
       "impact": "3x Response Rate",
       "title": "Personalized Candidate Outreach",
       "before": [
@@ -84,6 +92,7 @@
     {
       "id": "market-analysis",
       "category": "analysis",
+      "businessUnit": "gbs",
       "impact": "90% Accuracy",
       "title": "Automated Market Intelligence",
       "before": [
@@ -112,6 +121,7 @@
     {
       "id": "interview-prep",
       "category": "content",
+      "businessUnit": "rpo",
       "impact": "85% Better Prep",
       "title": "AI-Generated Interview Questions",
       "before": [
@@ -140,6 +150,7 @@
     {
       "id": "performance-reports",
       "category": "analysis",
+      "businessUnit": "msp",
       "impact": "70% Time Saved",
       "title": "Automated Performance Reporting",
       "before": [


### PR DESCRIPTION
## Summary
- add businessUnits list and tag each use case with a businessUnit id
- enable filtering by business unit and show unit badges on cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eb3bd8c48330be5e10b9c97f3692