### PR TITLE
Add interview scheduling and contract builder tools

### DIFF
--- a/contract-creation/builder.html
+++ b/contract-creation/builder.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contract Builder</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <a href="../index.html" class="hub-button">Back To Hub</a>
+    <div id="nav-placeholder"></div>
+    <main class="container mx-auto px-4 py-12">
+        <h1 class="text-3xl font-bold text-center mb-8">Contract Builder</h1>
+        <div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow">
+            <div class="grid gap-4 mb-4">
+                <input type="text" id="partyA" placeholder="Party A" class="border rounded p-2">
+                <input type="text" id="partyB" placeholder="Party B" class="border rounded p-2">
+                <input type="text" id="services" placeholder="Services" class="border rounded p-2">
+                <input type="date" id="date" class="border rounded p-2">
+                <textarea id="terms" rows="4" placeholder="Additional terms" class="border rounded p-2"></textarea>
+                <button id="generate" class="bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Generate Contract</button>
+                <textarea id="output" rows="10" class="border rounded p-2"></textarea>
+                <button id="download" class="bg-green-600 text-white py-2 rounded hover:bg-green-700">Download Markdown</button>
+                <a href="index.html" class="text-blue-600 underline text-center">Back to Contract Creation Hub</a>
+            </div>
+        </div>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script>
+        function buildContract() {
+            const partyA = document.getElementById('partyA').value || 'Party A';
+            const partyB = document.getElementById('partyB').value || 'Party B';
+            const services = document.getElementById('services').value || 'services';
+            const date = document.getElementById('date').value || new Date().toISOString().split('T')[0];
+            const terms = document.getElementById('terms').value || '';
+            return `# Service Contract\n\n**Date:** ${date}\n\n**Parties:**\n- ${partyA}\n- ${partyB}\n\n**Services:** ${services}\n\n${terms}\n\n---\n\nSigned,\n\n${partyA}\n\n${partyB}`;
+        }
+        document.getElementById('generate').addEventListener('click', function() {
+            document.getElementById('output').value = buildContract();
+        });
+        document.getElementById('download').addEventListener('click', function() {
+            const blob = new Blob([document.getElementById('output').value || buildContract()], { type: 'text/markdown' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'contract.md';
+            a.click();
+            URL.revokeObjectURL(url);
+        });
+    </script>
+    <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/scripts/navigation.js" defer></script>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/contract-creation/index.html
+++ b/contract-creation/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contract Creation</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <a href="../index.html" class="hub-button">Back To Hub</a>
+    <div id="nav-placeholder"></div>
+    <main class="container mx-auto px-4 py-12">
+        <h1 class="text-3xl font-bold text-center mb-8">Contract Creation</h1>
+        <div class="max-w-md mx-auto">
+            <div class="bg-white p-6 rounded-lg shadow text-center">
+                <h2 class="text-xl font-semibold mb-4">Contract Builder</h2>
+                <p class="mb-4">Generate simple agreements and download them as Markdown files.</p>
+                <a href="builder.html" class="inline-block bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700">Open Tool</a>
+            </div>
+        </div>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/scripts/navigation.js" defer></script>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/interview-scheduling/index.html
+++ b/interview-scheduling/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interview Scheduling</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <a href="../index.html" class="hub-button">Back To Hub</a>
+    <div id="nav-placeholder"></div>
+    <main class="container mx-auto px-4 py-12">
+        <h1 class="text-3xl font-bold text-center mb-8">Interview Scheduling</h1>
+        <div class="max-w-md mx-auto">
+            <div class="bg-white p-6 rounded-lg shadow text-center">
+                <h2 class="text-xl font-semibold mb-4">Invitation Generator</h2>
+                <p class="mb-4">Quickly draft interview invitations with date and time suggestions.</p>
+                <a href="scheduler.html" class="inline-block bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700">Open Tool</a>
+            </div>
+        </div>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/scripts/navigation.js" defer></script>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>

--- a/interview-scheduling/scheduler.html
+++ b/interview-scheduling/scheduler.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interview Invitation Generator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <a href="../index.html" class="hub-button">Back To Hub</a>
+    <div id="nav-placeholder"></div>
+    <main class="container mx-auto px-4 py-12">
+        <h1 class="text-3xl font-bold text-center mb-8">Invitation Generator</h1>
+        <div class="max-w-lg mx-auto bg-white p-6 rounded-lg shadow">
+            <div class="grid gap-4">
+                <input type="text" id="name" placeholder="Candidate Name" class="border rounded p-2">
+                <input type="date" id="date" class="border rounded p-2">
+                <input type="time" id="time" class="border rounded p-2">
+                <input type="text" id="location" placeholder="Location" class="border rounded p-2">
+                <button id="generate" class="bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Generate Invitation</button>
+                <textarea id="output" rows="6" class="border rounded p-2"></textarea>
+                <a href="index.html" class="text-blue-600 underline text-center">Back to Interview Scheduling Hub</a>
+            </div>
+        </div>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script>
+        document.getElementById('generate').addEventListener('click', function() {
+            const name = document.getElementById('name').value || 'Candidate';
+            const date = document.getElementById('date').value;
+            const time = document.getElementById('time').value;
+            const location = document.getElementById('location').value || 'our office';
+            const message = `Hello ${name},\n\nYou are invited to an interview on ${date} at ${time} in ${location}.\nPlease let us know if you have any questions.\n\nBest regards,\nRecruiting Team`;
+            document.getElementById('output').value = message;
+        });
+    </script>
+    <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/scripts/navigation.js" defer></script>
+    <script src="../shared/scripts/footer.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add interview scheduling hub and invitation generator with date, time, and location fields
- Add contract creation hub with form-based builder exporting markdown contracts

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5700077c8330b6828543dc0243f3