### PR TITLE
Add progress tracking with badges and API

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,5 +38,6 @@
   <script src="../shared/scripts/navigation.js" defer></script>
   <script src="../shared/scripts/footer.js" defer></script>
   <script src="../shared/scripts/dashboard.js" defer></script>
+  <script src="../shared/scripts/progress.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     <script src="shared/scripts/search.js" defer></script>
     <script src="shared/scripts/navigation.js" defer></script>
     <script src="shared/scripts/sections.js" defer></script>
+    <script src="shared/scripts/progress.js" defer></script>
     <script src="shared/announcement.js" defer></script>
     <script src="shared/scripts/footer.js" defer></script>
 </body>

--- a/shared/scripts/dashboard.js
+++ b/shared/scripts/dashboard.js
@@ -27,9 +27,17 @@ document.addEventListener('DOMContentLoaded', () => {
       const link = document.createElement('a');
       link.href = section.url;
       link.className = 'hub-card bg-white p-8 rounded-xl block';
+      // create id from url so progress tracking matches hub
+      const sectionId = section.id || section.url.replace(/\//g, '');
+      link.setAttribute('data-section-id', sectionId);
       link.innerHTML = `
         <h3 class="google-sans text-2xl font-bold mb-2">${section.title}</h3>
         <p class="text-gray-600">${section.description}</p>
+        <div class="mt-4">
+          <div class="progress-bar"><div class="progress-bar-fill"></div></div>
+          <div class="progress-label text-sm text-gray-600 mt-1">0% complete</div>
+          <div class="badge-container mt-2"></div>
+        </div>
       `;
       sectionsContainer.appendChild(link);
     });

--- a/shared/scripts/progress.js
+++ b/shared/scripts/progress.js
@@ -1,0 +1,64 @@
+const PROGRESS_KEY = 'sectionProgress';
+const BADGE_THRESHOLDS = [1, 5, 10];
+const BADGE_CLASSES = ['badge-bronze', 'badge-silver', 'badge-gold'];
+
+function getData() {
+  try {
+    return JSON.parse(localStorage.getItem(PROGRESS_KEY)) || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveData(data) {
+  localStorage.setItem(PROGRESS_KEY, JSON.stringify(data));
+}
+
+function markComplete(sectionId) {
+  if (!sectionId) return;
+  const data = getData();
+  data[sectionId] = (data[sectionId] || 0) + 1;
+  saveData(data);
+  updateProgressUI(sectionId);
+}
+
+function updateProgressUI(sectionId) {
+  const data = getData();
+  const count = data[sectionId] || 0;
+  const max = BADGE_THRESHOLDS[BADGE_THRESHOLDS.length - 1];
+  const percent = Math.min((count / max) * 100, 100);
+
+  const card = document.querySelector(`[data-section-id="${sectionId}"]`);
+  if (!card) return;
+
+  const bar = card.querySelector('.progress-bar-fill');
+  if (bar) bar.style.width = `${percent}%`;
+
+  const label = card.querySelector('.progress-label');
+  if (label) label.textContent = `${Math.round(percent)}% complete`;
+
+  const badgeContainer = card.querySelector('.badge-container');
+  if (badgeContainer) {
+    badgeContainer.innerHTML = '';
+    BADGE_THRESHOLDS.forEach((th, idx) => {
+      if (count >= th) {
+        const span = document.createElement('span');
+        span.className = `badge ${BADGE_CLASSES[idx]}`;
+        span.textContent = BADGE_CLASSES[idx].replace('badge-', '').toUpperCase();
+        badgeContainer.appendChild(span);
+      }
+    });
+  }
+}
+
+function initProgressUI() {
+  document.querySelectorAll('[data-section-id]').forEach(card => {
+    const id = card.getAttribute('data-section-id');
+    updateProgressUI(id);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initProgressUI);
+
+// expose API globally
+window.markComplete = markComplete;

--- a/shared/scripts/sections.js
+++ b/shared/scripts/sections.js
@@ -14,9 +14,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const link = document.createElement('a');
         link.href = section.url;
         link.className = 'hub-card bg-white p-8 rounded-xl block';
+        // derive a section id from the url (/path/ -> path)
+        const sectionId = section.id || section.url.replace(/\//g, '');
+        link.setAttribute('data-section-id', sectionId);
         link.innerHTML = `
           <h3 class="google-sans text-2xl font-bold mb-2">${section.title}</h3>
           <p class="text-gray-600">${section.description}</p>
+          <div class="mt-4">
+            <div class="progress-bar"><div class="progress-bar-fill"></div></div>
+            <div class="progress-label text-sm text-gray-600 mt-1">0% complete</div>
+            <div class="badge-container mt-2"></div>
+          </div>
         `;
         container.appendChild(link);
       });

--- a/style.css
+++ b/style.css
@@ -29,3 +29,31 @@ body {
 .hub-card h3 {
     color: #1967d2; /* Google Blue */
 }
+
+/* progress tracking */
+.progress-bar {
+    width: 100%;
+    height: 8px;
+    background-color: #e5e7eb;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.progress-bar-fill {
+    height: 100%;
+    width: 0%;
+    background-color: #3b82f6;
+}
+
+.badge {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    color: #fff;
+    margin-right: 4px;
+}
+
+.badge-bronze { background-color: #cd7f32; }
+.badge-silver { background-color: #c0c0c0; color: #000; }
+.badge-gold { background-color: #ffd700; color: #000; }


### PR DESCRIPTION
## Summary
- add `progress.js` for localStorage-based progress tracking and expose `markComplete(sectionId)` API
- render progress bars and badges on hub and dashboard cards
- style progress bar and badge elements

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba59c53a3083309fd5ae1cb64c9de2