### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/shared/navigation.html
+++ b/shared/navigation.html
@@ -1,3 +1,4 @@
 <nav class="bg-white border-b border-gray-200 px-4 py-3 flex items-center">
   <a href="/index.html" class="font-semibold text-blue-600">Randstad GBS</a>
+  <button id="theme-toggle" class="ml-auto text-xl" aria-label="Toggle theme">🌙</button>
 </nav>

--- a/shared/scripts/navigation.js
+++ b/shared/scripts/navigation.js
@@ -3,14 +3,32 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!placeholder) return;
   const path = window.location.pathname;
   const depth = path.split('/').length - 2;
-  const relativePath = '../'.repeat(depth > 0 ? depth : 0) + 'shared/navigation.html';
-  fetch(relativePath)
+  const basePath = '../'.repeat(depth > 0 ? depth : 0) + 'shared/';
+  const navPath = basePath + 'navigation.html';
+  fetch(navPath)
     .then(res => res.text())
     .then(html => {
       placeholder.innerHTML = html;
+      if (window.applyTheme) {
+        loadScript(basePath + 'scripts/theme-toggle.js');
+      } else {
+        loadScript(basePath + 'scripts/theme.js', () => {
+          loadScript(basePath + 'scripts/theme-toggle.js');
+        });
+      }
       if (window.setupSearch) {
         window.setupSearch();
       }
     })
     .catch(err => console.error('Error loading navigation:', err));
+
+  function loadScript(src, callback) {
+    const s = document.createElement('script');
+    s.src = src;
+    s.defer = true;
+    if (callback) {
+      s.onload = callback;
+    }
+    document.head.appendChild(s);
+  }
 });

--- a/shared/scripts/theme-toggle.js
+++ b/shared/scripts/theme-toggle.js
@@ -1,0 +1,23 @@
+// Toggles between light and dark themes
+// and persists the choice in localStorage.
+const toggleBtn = document.getElementById('theme-toggle');
+if (toggleBtn) {
+    const currentTheme = document.documentElement.dataset.theme || 'light';
+    setIcon(currentTheme);
+
+    toggleBtn.addEventListener('click', () => {
+        const html = document.documentElement;
+        const activeTheme = html.dataset.theme === 'dark' ? 'dark' : 'light';
+        const newTheme = activeTheme === 'dark' ? 'light' : 'dark';
+        html.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+        if (window.applyTheme) {
+            window.applyTheme(newTheme);
+        }
+        setIcon(newTheme);
+    });
+
+    function setIcon(theme) {
+        toggleBtn.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+}

--- a/shared/scripts/theme.js
+++ b/shared/scripts/theme.js
@@ -16,3 +16,43 @@ tailwind.config = {
         }
     }
 };
+
+const lightTheme = {
+    '--ai-bg': '#ffffff',
+    '--ai-text': '#1f2937',
+    '--ai-heading': '#1f2937',
+    '--ai-accent': '#3b82f6',
+    '--ai-accent-hover': '#2563eb',
+    '--ai-card': '#f3f4f6',
+    '--ai-border': '#e5e7eb',
+    '--ai-shadow-sm': '0 1px 2px rgba(0, 0, 0, 0.05)',
+    '--ai-shadow-md': '0 4px 6px rgba(0, 0, 0, 0.1)'
+};
+
+const darkTheme = {
+    '--ai-bg': '#1f2937',
+    '--ai-text': '#f9fafb',
+    '--ai-heading': '#f9fafb',
+    '--ai-accent': '#3b82f6',
+    '--ai-accent-hover': '#60a5fa',
+    '--ai-card': '#374151',
+    '--ai-border': '#4b5563',
+    '--ai-shadow-sm': '0 1px 2px rgba(0, 0, 0, 0.4)',
+    '--ai-shadow-md': '0 4px 6px rgba(0, 0, 0, 0.6)'
+};
+
+const themes = { light: lightTheme, dark: darkTheme };
+
+function applyTheme(theme) {
+    const palette = themes[theme] || lightTheme;
+    const root = document.documentElement;
+    Object.entries(palette).forEach(([key, value]) => {
+        root.style.setProperty(key, value);
+    });
+}
+
+window.applyTheme = applyTheme;
+
+const storedTheme = localStorage.getItem('theme') || 'light';
+document.documentElement.setAttribute('data-theme', storedTheme);
+applyTheme(storedTheme);


### PR DESCRIPTION
## Summary
- Define light and dark CSS variable palettes and apply stored theme on load
- Add navigation button with script to toggle themes and persist choice
- Dynamically load theme and toggle scripts whenever navigation is injected

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ba5fc15a3c83309f54814cc8192a26