### PR TITLE
Add updates feed and homepage preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
             </div>
         </header>
 
+        <section id="latest-updates" class="max-w-2xl mx-auto mb-12">
+            <h2 class="text-2xl font-bold text-center mb-4">Latest Updates</h2>
+            <ul id="latest-updates-list" class="space-y-2 text-left"></ul>
+            <a href="updates/" class="text-blue-600 hover:underline block text-center mt-4">View all updates</a>
+        </section>
+
         <main>
             <div id="hub-sections" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto"></div>
         </main>
@@ -38,6 +44,7 @@
     <script src="shared/scripts/progress.js" defer></script>
     <script src="shared/announcement.js" defer></script>
     <script src="shared/scripts/footer.js" defer></script>
+    <script src="updates/latest-updates.js" defer></script>
 </body>
 
 </html>

--- a/updates/index.html
+++ b/updates/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Updates | Randstad GBS AI Hub</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../shared/hub-button.css">
+    <link rel="stylesheet" href="../shared/announcement.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <a href="../index.html" class="hub-button">Back To Hub</a>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+        <h1 class="text-4xl md:text-5xl font-bold text-center mb-12">Updates</h1>
+        <ul id="updates-container" class="space-y-4"></ul>
+    </main>
+
+    <div id="footer-placeholder"></div>
+    <script src="../shared/announcement.js" defer></script>
+    <script src="../shared/scripts/footer.js" defer></script>
+    <script src="updates.js" defer></script>
+</body>
+</html>

--- a/updates/latest-updates.js
+++ b/updates/latest-updates.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('updates/updates.json')
+        .then(res => res.json())
+        .then(items => {
+            items.sort((a, b) => new Date(b.date) - new Date(a.date));
+            const list = document.getElementById('latest-updates-list');
+            const top = items.slice(0, 3);
+            top.forEach(({ date, title, url }) => {
+                const li = document.createElement('li');
+                const link = document.createElement('a');
+                link.href = url;
+                link.textContent = title;
+                link.className = 'text-blue-600 hover:underline';
+
+                const span = document.createElement('span');
+                span.textContent = ` - ${date}`;
+                span.className = 'text-sm text-gray-500';
+
+                li.appendChild(link);
+                li.appendChild(span);
+                list.appendChild(li);
+            });
+        })
+        .catch(err => console.error('Failed to load latest updates:', err));
+});

--- a/updates/updates.js
+++ b/updates/updates.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('updates.json')
+        .then(res => res.json())
+        .then(items => {
+            items.sort((a, b) => new Date(b.date) - new Date(a.date));
+            const container = document.getElementById('updates-container');
+            items.forEach(({ date, title, url }) => {
+                const li = document.createElement('li');
+                li.className = 'border border-gray-200 rounded-lg p-4 bg-white';
+
+                const link = document.createElement('a');
+                link.href = '../' + url;
+                link.textContent = title;
+                link.className = 'text-blue-600 hover:underline font-medium';
+
+                const span = document.createElement('span');
+                span.textContent = ` - ${date}`;
+                span.className = 'text-sm text-gray-500';
+
+                li.appendChild(link);
+                li.appendChild(span);
+                container.appendChild(li);
+            });
+        })
+        .catch(err => console.error('Failed to load updates:', err));
+});

--- a/updates/updates.json
+++ b/updates/updates.json
@@ -1,0 +1,6 @@
+[
+  {"date": "2024-06-01", "title": "Introduced AI Ethics course", "url": "ai-ethics/"},
+  {"date": "2024-05-15", "title": "Updated FAQ section", "url": "faq/"},
+  {"date": "2024-05-01", "title": "New AI Glossary", "url": "ai-glossary/"},
+  {"date": "2024-04-20", "title": "Launched Daily Focus feature", "url": "daily-focus/"}
+]


### PR DESCRIPTION
## Summary
- Provide `updates/updates.json` for centralized update metadata
- Create updates index page and script to list items chronologically
- Surface three latest updates on homepage with link to full list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba859d7ac08330a208b39b575ce3a1